### PR TITLE
Implement an outline for the whole setup workflow

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,2 @@
 version = 0.21.0
+parse-docstrings=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,3 @@ FROM ubuntu
 RUN apt update
 RUN apt install -y gcc make patch unzip bubblewrap curl
 COPY _build/default/bin/main.exe /usr/local/bin/ocaml-platform
-RUN printf "\n" | ocaml-platform
-RUN opam -v

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,15 +1,12 @@
+open! Platform.Import
 open Cmdliner
 
-let doc = "Install opam"
+let main =
+  let doc = "Set-up everything you need to hack in OCaml." in
+  Cmd.group
+    (Cmd.info "ocaml-platform" ~version:"%%VERSION%%"
+       ~doc (* ~sdocs ~exits ~man *))
+    [ Setup.local_cmd; Setup.global_cmd ]
 
-let man =
-  [
-    `S Manpage.s_description;
-    `P "$(tname) installs opam, if it isn't already installed.";
-  ]
-
-let install () = ignore @@ Platform.Opam_installer.install_opam ()
-let term = Term.(const install $ const ())
-let info = Cmd.info "install opam" ~doc ~man
-let cmd = Cmd.v info term
-let () = exit (Cmd.eval cmd)
+let main () = Stdlib.exit @@ Cmd.eval' main
+let () = main ()

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -1,0 +1,68 @@
+open! Platform.Import
+open Cmdliner
+open Result.Direct
+
+let exec ~skip ~err f =
+  if skip then Ok ()
+  else
+    f ()
+    |> Result.map_error (fun (`Msg msg) ->
+           Platform.UserInteractions.errorf "%s" msg;
+           err)
+
+let handle_errs =
+  Result.map_error (fun l ->
+      List.iter (fun (`Msg msg) -> Platform.UserInteractions.errorf "%s" msg) l;
+      List.length l)
+
+let do_all ~yes switch =
+  let setup_res =
+    let open Platform.Opam in
+    let* () = exec ~skip:(is_installed ()) ~err:30 (install ~yes) in
+    let* () = exec ~skip:(is_initialized ()) ~err:31 (init ~yes) in
+    let* () =
+      exec ~skip:(switch_exists switch) ~err:32 (make_switch ~yes switch)
+    in
+    Platform.Tools.(install ~yes platform) |> handle_errs
+  in
+  match setup_res with Ok () -> 0 | Error st -> st
+
+let local_setup yes = function
+  | None -> do_all ~yes (Local ".")
+  | Some dir -> do_all ~yes (Local dir)
+
+let global_setup yes = function
+  | None ->
+      (* FIXME: this should be the latest stable compiler, not a hard-coded 4.14.0 *)
+      do_all ~yes (Global "4.14.0")
+  | Some comp -> do_all ~yes (Global comp)
+
+let local_arg =
+  let doc =
+    "The project directory for the local switch. Defaults to the current \
+     working directory."
+  in
+  Arg.(value & opt (some' string) None & info [ "d"; "dir" ] ~docv:"DIR" ~doc)
+
+let global_arg =
+  let doc =
+    "The compiler you'd like to have in your global switch. Defaults to the \
+     latest stable compiler."
+  in
+  Arg.(value & opt (some' string) None & info [ "c"; "comp" ] ~docv:"COMP" ~doc)
+
+let yes =
+  let doc = "Just keep going without stopping to prompt for confirmation" in
+  Arg.(value & flag & info [ "y"; "yes" ] ~doc)
+
+let local_cmd =
+  let term = Term.(const local_setup $ yes $ local_arg) in
+  (* FIXME: let's find something shorter *)
+  let info = Cmd.info "setup-local" in
+  Cmd.v info term
+
+let global_cmd =
+  let term = Term.(const global_setup $ yes $ global_arg) in
+  (* FIXME: let's find something shorter *)
+  let info = Cmd.info "setup-global" in
+  Cmd.v info term

--- a/bin/setup.mli
+++ b/bin/setup.mli
@@ -1,0 +1,14 @@
+val local_cmd : int Cmdliner.Cmd.t
+(** The command that does the full set-up of installing and initializing opam,
+    creating a local switch and populating it with all platform tools and
+    installing all project dependencies in there. The project directory the
+    switch is for can be speficied as an argument; if none is specified, we use
+    the current working directory. Each of the mentioned steps is only realized
+    if its result doesn't already exist. *)
+
+val global_cmd : int Cmdliner.Cmd.t
+(** The command that does the full set-up of installing and initializing opam,
+    creating a global switch and populating it with all platform tools. The
+    compiler for the switch can be specified as an argument; if none is
+    specified, we use the latest stable compiler. Each of the mentioned steps is
+    only realized if its result doesn't already exist. *)

--- a/dune-project
+++ b/dune-project
@@ -30,4 +30,7 @@
   ocaml
   dune
   (cmdliner
-   (>= 1.1.0))))
+   (>= 1.1.0))
+  bos
+  result
+  rresult))

--- a/lib/dune
+++ b/lib/dune
@@ -1,2 +1,3 @@
 (library
- (name platform))
+ (name platform)
+ (libraries bos.setup result rresult))

--- a/lib/import.ml
+++ b/lib/import.ml
@@ -1,0 +1,8 @@
+module Result = struct
+  include Result
+
+  module Direct = struct
+    let ( let+ ) x f = Result.map f x
+    let ( let* ) x f = Result.bind x f
+  end
+end

--- a/lib/import.mli
+++ b/lib/import.mli
@@ -1,0 +1,46 @@
+(** Adding convenience functions to the standard library to favor a consistent
+    code style throughout the project. Let's [open!] this in every module. *)
+
+module Result : sig
+  type ('a, 'e) t = ('a, 'e) result = Ok of 'a | Error of 'e
+
+  val ok : 'a -> ('a, 'e) result
+  val error : 'e -> ('a, 'e) result
+  val value : ('a, 'e) result -> default:'a -> 'a
+  val get_ok : ('a, 'e) result -> 'a
+  val get_error : ('a, 'e) result -> 'e
+  val bind : ('a, 'e) result -> ('a -> ('b, 'e) result) -> ('b, 'e) result
+  val join : (('a, 'e) result, 'e) result -> ('a, 'e) result
+  val map : ('a -> 'b) -> ('a, 'e) result -> ('b, 'e) result
+  val map_error : ('e -> 'f) -> ('a, 'e) result -> ('a, 'f) result
+  val fold : ok:('a -> 'c) -> error:('e -> 'c) -> ('a, 'e) result -> 'c
+  val iter : ('a -> unit) -> ('a, 'e) result -> unit
+  val iter_error : ('e -> unit) -> ('a, 'e) result -> unit
+  val is_ok : ('a, 'e) result -> bool
+  val is_error : ('weak3, 'e) result -> bool
+
+  val equal :
+    ok:('a -> 'a -> bool) ->
+    error:('e -> 'e -> bool) ->
+    ('a, 'e) result ->
+    ('a, 'e) result ->
+    bool
+
+  val compare :
+    ok:('a -> 'a -> int) ->
+    error:('e -> 'e -> int) ->
+    ('a, 'e) result ->
+    ('a, 'e) result ->
+    int
+
+  val to_option : ('a, 'e) result -> 'a option
+  val to_list : ('a, 'e) result -> 'a list
+  val to_seq : ('a, 'e) result -> 'a Seq.t
+
+  type ('a, 'b) result = ('a, 'b) Result.result = Ok of 'a | Error of 'b
+
+  module Direct : sig
+    val ( let+ ) : ('a, 'b) t -> ('a -> 'c) -> ('c, 'b) t
+    val ( let* ) : ('a, 'b) t -> ('a -> ('c, 'b) t) -> ('c, 'b) t
+  end
+end

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -1,0 +1,46 @@
+open! Import
+open Bos_setup
+
+let install ~yes:_ () =
+  (* FIXME: implement this in OCaml instead of running the opam script and adapt it to our ideas. In particular, take [yes] into account instead of ignoring it :P *)
+  let install_sh =
+    "bash -c \"sh <(curl -fsSL \
+     https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)\""
+  in
+  let exit = Sys.command install_sh in
+  if exit = 0 then Ok ()
+  else Error (`Msg "Something went wrong trying to install opam.")
+
+let is_installed () =
+  (*FIXME*)
+  false
+(* FIXME: implement this in OCaml instead of running the opam script *)
+
+let add_yes ~yes cmd = if yes then Cmd.(cmd % "--yes") else cmd
+
+let init ~yes () =
+  (* FIXME: implement this in OCaml instead of running the opam script and adapt it to our ideas. In particular, take [yes] into account instead of ignoring it :P *)
+  let base_cmd = Cmd.(v "opam" % "init" % "--bare") in
+  let cmd = add_yes ~yes base_cmd in
+  OS.Cmd.run_io cmd OS.Cmd.in_stdin |> OS.Cmd.to_stdout
+
+let is_initialized () =
+  (* FIXME *)
+  false
+
+type switch = Local of string | Global of string
+(* FIXME: use Fpath.t for the parameter of [Local] and something like ... for the parameter of [Global] *)
+
+let make_switch ~yes switch () =
+  let base_cmd =
+    match switch with
+    | Local dir ->
+        Cmd.(v "opam" % "switch" % "create" % dir % "--deps-only" % "with-test")
+    | Global comp -> Cmd.(v "opam" % "switch" % "create" % comp)
+  in
+  let cmd = add_yes ~yes base_cmd in
+  OS.Cmd.run_io cmd OS.Cmd.in_stdin |> OS.Cmd.to_stdout
+
+let switch_exists _switch =
+  (* FIXME *)
+  false

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -1,0 +1,22 @@
+val install : yes:bool -> unit -> (unit, [> Rresult.R.msg ]) result
+(** Installs opam (currently by executing the opam shell script)*)
+
+val is_installed : unit -> bool
+(** Checks if opam is already installed or not.*)
+
+val init : yes:bool -> unit -> (unit, [> Rresult.R.msg ]) result
+(** Initializes opam without setting up a switch *)
+
+val is_initialized : unit -> bool
+(** Checks if opam is already initialized or not.*)
+
+type switch = Local of string | Global of string
+(* FIXME: use Fpath.t for the parameter of [Local] and something like ... for the parameter of [Global. *)
+
+val make_switch :
+  yes:bool -> switch -> unit -> (unit, [> Rresult.R.msg ]) result
+(** [make_switch switch] creates a switch [switch]. If the switch is local, it
+    also installs the project dependencies, including test dependencies. *)
+
+val switch_exists : switch -> bool
+(** Checks if the given switch already exists. *)

--- a/lib/opam_installer.ml
+++ b/lib/opam_installer.ml
@@ -1,6 +1,0 @@
-let install_opam () =
-  let install_sh =
-    "bash -c \"sh <(curl -fsSL \
-     https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)\""
-  in
-  Sys.command install_sh

--- a/lib/opam_installer.mli
+++ b/lib/opam_installer.mli
@@ -1,2 +1,0 @@
-val install_opam : unit -> int
-(** Installs opam (currently by executing the opam shell script) *)

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -1,0 +1,47 @@
+open! Import
+open Bos_setup
+
+let comp_independent = [ "dune"; "utop"; "dune-release" ]
+let comp_dependent = [ "merlin"; "ocaml-lsp-server"; "odoc"; "ocamlformat" ]
+
+type t = {
+  name : string;
+  compiler_constr : string option;
+  description : string option;
+}
+(* FIXME: Once we use the opam library, let's use something like [OpamPackage.Name.t] for the type of [name] and something like ... for the type of [compiler_constr].*)
+
+let install_one ~yes { name; compiler_constr = _; description } =
+  (* TODO: check first if the tool is already installed before installing it *)
+  let descr = Option.value ~default:"" description in
+  UserInteractions.logf "We're currently installing %s. %s\n" name descr;
+  (* FIXME: implement a caching and sandboxing workflow. for the sandboxing, take [compiler_constr] into account *)
+  let base_cmd = Cmd.(v "opam" % "install" % name) in
+  let cmd = if yes then Cmd.(base_cmd % "--yes") else base_cmd in
+  OS.Cmd.run_io cmd OS.Cmd.in_stdin |> OS.Cmd.to_stdout
+
+let install ~yes tools =
+  let iterate res tools =
+    List.fold_left
+      (fun last_res tool ->
+        match (last_res, install_one ~yes tool) with
+        | Ok (), Ok () -> Ok ()
+        | Error l, Ok () -> Error l
+        | Ok (), Error err -> Error [ err ]
+        | Error l, Error err -> Error (err :: l))
+      res tools
+  in
+  iterate (Ok ()) tools
+
+let platform =
+  (* FIXME: should take an argument of type [OpamStateTypes.switch_state] from the opam library or something like that and use that argument for the [compiler_constr] field of the compiler dependent tools *)
+  (* FIXME: should add a brief description for each tool *)
+  let independent =
+    List.map
+      (fun tool -> { name = tool; compiler_constr = None; description = None })
+      comp_independent
+  in
+  List.fold_left
+    (fun acc tool ->
+      { name = tool; compiler_constr = None; description = None } :: acc)
+    independent comp_dependent

--- a/lib/tools.mli
+++ b/lib/tools.mli
@@ -1,0 +1,16 @@
+type t = {
+  name : string;
+  compiler_constr : string option;
+  description : string option;
+}
+(* FIXME: Once we use the opam library, let's use something like [OpamPackage.Name.t] for the type of [name] and something like ... for the type of [compiler_constr].*)
+
+val install : yes:bool -> t list -> (unit, [> Rresult.R.msg ] list) result
+(** [install tools] installs each tool in [tools] inside the current switch, if
+    it isn't already installed*)
+
+val platform : t list
+(** All tools in the current state of the OCaml Platform. (TODO: For the
+    compiler version dependent tools, the [compiler_constr] should be the
+    compiler version of the current swtich.) *)
+(* FIXME: should take an argument of type [OpamStateTypes.switch_state] from the opam library or something like that instead of unit *)

--- a/lib/userInteractions.ml
+++ b/lib/userInteractions.ml
@@ -1,0 +1,8 @@
+(* FIXME: implement the different functions instead of just printing / having dummy placefolders *)
+
+let errorf = Printf.printf
+let logf = Printf.printf
+
+let prompt question =
+  Printf.printf question;
+  true

--- a/lib/userInteractions.mli
+++ b/lib/userInteractions.mli
@@ -1,0 +1,9 @@
+val errorf : ('a, out_channel, unit) format -> 'a
+(** Prints an error to stderr (well, not yet. currently just prints it) *)
+
+val logf : ('a, out_channel, unit) format -> 'a
+(** Logs to stdout *)
+
+val prompt : (unit, out_channel, unit) format -> bool
+(** [prompt question] starts a prompt asking the user [question]. It returns
+    [true] and [false] if the user answers [yes] and [no], respectively *)

--- a/platform.opam
+++ b/platform.opam
@@ -21,6 +21,9 @@ depends: [
   "ocaml"
   "dune" {>= "3.0"}
   "cmdliner" {>= "1.1.0"}
+  "bos"
+  "result"
+  "rresult"
   "odoc" {with-doc}
 ]
 build: [

--- a/test/bin/test.sh
+++ b/test/bin/test.sh
@@ -2,8 +2,15 @@
 set -euo pipefail
 
 docker build -t test .
-# docker run --rm -it --privileged test
-# docker run --rm -i -v $(pwd)/_build/default/bin:/root/platform --privileged test <<EOF
-# ./root/platform/main.exe
-# opam init -y
-# EOF
+docker run -i -v $(pwd)/_build/default/bin/main.exe:/usr/local/bin/ocaml-platform --privileged test <<EOF
+printf "\n" | ocaml-platform setup-global --yes
+eval \$(opam env)
+opam --version
+dune --version
+utop -version
+dune-release --version
+dune ocaml-merlin --version
+odoc --version
+ocamlformat --version
+EOF
+# ocaml-lsp-server is missing. how can we check if it's installed?


### PR DESCRIPTION
I've just "implemented" an outline for the first step of the installer. I'm calling it an "outline" rather than an implementation, because -as you can see- there are currently almost more `TODO`s and `FIXME`s than actual code. Also, what really matters, i.e. the sandboxing and caching workflow when installing the tools, isn't implemented yet. The structure for the commands is the one we've agreed on, @Julow and @panglesd, so I'll skip summarizing how it looks like here in the description (also, the two commands "implemented" so far are described [here](https://github.com/tarides/ocaml-platform/compare/main...pitag-ha:install-tools?expand=1#diff-8af39e04df45e6fd09b6205171849b89c6b92f78f9bb246aaa4e885285bc735b)). Let me know what you think! The idea for this is to serve as a base. Most of the `TODO`s and `FIXME`s can then be issues we can all work on (together with more issues...).