### PR TITLE
Install the default switch if there's none

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -15,6 +15,7 @@ let install_platform opam_opts =
     let open Result.Syntax in
     let* () = Platform.Opam.install () in
     let _ = Platform.Opam.check_init ~opts:opam_opts () in
+    let* () = Platform.Opam.Switch.install ~opts:opam_opts [] in
     match Platform.Tools.(install opam_opts platform) with
     | Ok () -> Ok ()
     | Error errs ->

--- a/src/lib/opam.mli
+++ b/src/lib/opam.mli
@@ -59,12 +59,15 @@ module Switch : sig
       installed. *)
 end
 
+(* TODO: Abstract the switch_state into [Switch.t] and pass it to every
+   functions of [Switch]. To avoid internally calling [check_init] and
+   [Global.apply] many times. *)
 val check_init :
   ?opts:OpamArg.global_options ->
   unit ->
   OpamStateTypes.rw OpamStateTypes.global_state
   * OpamStateTypes.unlocked OpamStateTypes.repos_state
-  * OpamFormula.atom list
+  * OpamStateTypes.rw OpamStateTypes.switch_state
 
 val install : unit -> (unit, [> `Msg of string ]) result
 (** Installs opam (currently by executing the opam shell script). *)


### PR DESCRIPTION
Opam functions need at least one switch to work properly. The sandbox/caching patch also depend on a selected switch.