### PR TITLE
updated readme after first release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OCaml Platform
 
+> :bangbang: Disclaimer: This repository is very much a work in progress. Use at your own risk. :wrench:
+
 The OCaml Platform represents the best way for developers, both new and old, to write software in OCaml. It combines the core OCaml compiler with a coherent set of tools, documentation, libraries and testing resources.
 
 This repository contains the `ocaml-platform` tool. This tool allows to easily install all the projects of the Platform in a switch and aims at offering a unified workflow to work with the different Platform tools.
@@ -10,7 +12,7 @@ Just download and execute the [install script](https://github.com/tarides/ocaml-
 
 The install script simply downloads and installs the suitable version of `ocaml-platform` for your system, as well as `opam` if needed.
 
-You are then able to run `ocaml-platform`. It will install the platform tools in the current switch. Note that the first time the command is run for a given version of ocaml, installing the switch takes a few minutes.
+You are then able to run `ocaml-platform`. It will install the platform tools in the current switch. Note that the first time the command is run for a given version of ocaml, installing the tools for the switch takes a few minutes.
 
 ### The advantages of using `ocaml-platform`
 


### PR DESCRIPTION
When the project become public, the README should reflect what the project currently does, not what it aims to do in the future (e.g. being a unified CLI), to not confuse the user.
The long term goal of the project could be mentioned, but making it clear that it is a long term goal.

The readme should also mention how to install and use the tool.