### PR TITLE
Distrib: Improve the std outputs of the installer

### DIFF
--- a/src/distrib/make_installer.sh
+++ b/src/distrib/make_installer.sh
@@ -101,7 +101,7 @@ if ! [[ -e \$PREFIX/bin/opam ]]; then
   install_opam
 fi
 
-echo "Installation is done. Please run 'ocaml-platform' to setup the platform."
+echo "Installation is done. Please run 'ocaml-platform' to install the Platform tools inside your set switch."
 }
 
 # Now that we know the whole script has downloaded, run it.


### PR DESCRIPTION
Remove the -x flag, which is unreadable now that the script grew.
Add logging at every important steps and more importantly, in case of a problem.

The new output is:

```
=> Download ocaml-platform-42-linux-x86_64.tar
=> Install into /usr/local/bin
Opam is not installed, installing.
=> Download opam-2.1.2-x86_64-linux
Connecting to github.com (140.82.121.4:443)
Connecting to objects.githubusercontent.com (185.199.110.133:443)
saving to 'opam'
opam                 100% |*******************************************| 7068k  0:00:00 ETA
'opam' saved
=> Install into /usr/local/bin
Installation is done. Please run 'ocaml-platform' to setup the platform.
```

When it fails while installing Opam, it shows this:

```
=> Download ocaml-platform-42-linux-x86_64.tar
=> Install into /usr/local/bin
Opam is not installed, installing.
Cannot install opam for linux x86_64.
Opam is required to setup the platform. Please install it via your package manager or obtai
n it at https://opam.ocaml.org/
Once Opam is installed, run 'ocaml-platform'.
```
