### PR TITLE
Create the sandbox switch in a temporary directory

### DIFF
--- a/src/lib/sandbox_switch.ml
+++ b/src/lib/sandbox_switch.ml
@@ -8,7 +8,8 @@ type t = {
   prefix : Fpath.t;
       (** Root directory of the switch, containing [bin/], [lib/], etc.. *)
   sandbox_root : Fpath.t;
-      (** The directory in which the sandbox switch has been created. *)
+      (** The directory in which the sandbox switch has been created. Created
+          during [init] and removed during [deinit]. *)
   compiler_path : Fpath.t;
       (** A folder containing symlinks to the compiler tools. Created during
           [init] and removed during [deinit]. *)


### PR DESCRIPTION
The sandbox switch is now a local switch into a temporary directory,
which can be cleaned up more easily and can't be used concurrently.

It still shows in 'opam switch list' but it now has a weirder name.

A cleanup step is still needed, but if it fails, the switch will
eventually be removed by the system and Opam will automatically cleanup
its states.
We don't remove the reference to the sandbox switch from Opam's state
because it's still useful to know about switch that would not be cleaned
up automatically by the system.