### PR TITLE
Fix crash while parsing version constraints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Fix crash while parsing version constraints (#70)
 - Speed-up creating the sandbox switch (#56)
 - Improve the installer script's output (#62)
 - Add a `DETAILS` section to the man page (#54)


### PR DESCRIPTION
The '=' operator was parsed but not handled afterward. Fix it by
simplifying the code and not using strings.

This bug is new because the problematic version constraint is new.