### PR TITLE
Use a `.install` file when possible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Use an install file instead of install instruction in binary package (#73)
 - Better logs, including few sliding lines of opam output when necessary (#57)
 - Fix duplicate files in binary package archive (#71)
 

--- a/dune-project
+++ b/dune-project
@@ -38,4 +38,5 @@
   bos
   ANSITerminal
   lwt
+  opam-file-format
   ppxlib))

--- a/platform.opam
+++ b/platform.opam
@@ -30,6 +30,7 @@ depends: [
   "bos"
   "ANSITerminal"
   "lwt"
+  "opam-file-format"
   "ppxlib"
   "odoc" {with-doc}
 ]

--- a/src/lib/binary_package.ml
+++ b/src/lib/binary_package.ml
@@ -32,11 +32,7 @@ module Binary_install_file = struct
          l
 
   let from_file_list pkg_name fl =
-    let empty =
-      let open String.Map in
-      empty |> add "bin" [] |> add "sbin" [] |> add "share" []
-      |> add "share_root" [] |> add "doc" [] |> add "etc" [] |> add "man" []
-    in
+    let empty = String.Map.empty in
     let classified_files = List.fold_left (classify_file pkg_name) empty fl in
     let process =
       List.map (fun (n, f) -> (Fpath.to_string n, Some (Fpath.to_string f)))

--- a/src/lib/binary_package.ml
+++ b/src/lib/binary_package.ml
@@ -3,6 +3,79 @@ open Result.Syntax
 open Astring
 open Bos
 
+module Binary_install_file = struct
+  type classified_files = {
+    bin : (Fpath.t * Fpath.t) list;
+    sbin : (Fpath.t * Fpath.t) list;
+    share : (Fpath.t * Fpath.t) list;
+    share_root : (Fpath.t * Fpath.t) list;
+    etc : (Fpath.t * Fpath.t) list;
+    doc : (Fpath.t * Fpath.t) list;
+    man : (Fpath.t * Fpath.t) list;
+    other : Fpath.t list;
+  }
+
+  let classify_file pkg_name cf f =
+    let open Fpath in
+    let f = v f in
+    let f = match rem_prefix (v "_opam") f with None -> f | Some f -> f in
+    let l =
+      (* prefix, setter *)
+      [
+        (v "bin", fun cf v -> { cf with bin = v :: cf.bin });
+        (v "sbin", fun cf v -> { cf with sbin = v :: cf.sbin });
+        (v "share" / pkg_name, fun cf v -> { cf with share = v :: cf.share });
+        (v "share_root", fun cf v -> { cf with share_root = v :: cf.share_root });
+        (v "doc" / pkg_name, fun cf v -> { cf with doc = v :: cf.doc });
+        (v "etc" / pkg_name, fun cf v -> { cf with etc = v :: cf.etc });
+        (v "man" / pkg_name, fun cf v -> { cf with man = v :: cf.man });
+      ]
+    in
+    Option.value ~default:{ cf with other = f :: cf.other }
+    @@ List.find_map
+         (fun (value, setter) ->
+           Option.map (fun p -> setter cf (f, p)) (rem_prefix value f))
+         l
+
+  let from_file_list pkg_name fl =
+    match
+      List.fold_left (classify_file pkg_name)
+        {
+          bin = [];
+          sbin = [];
+          share = [];
+          share_root = [];
+          etc = [];
+          doc = [];
+          man = [];
+          other = [];
+        }
+        fl
+    with
+    | { other = _ :: _ as other; _ } ->
+        List.iter
+          (fun file ->
+            Logs.debug (fun m ->
+                m "%s does not apply for a .install file due to %s" pkg_name
+                  (Fpath.to_string file)))
+          other;
+        None
+    | { bin; sbin; share; share_root; etc; doc; man; other = [] } ->
+        let process =
+          List.map (fun (n, f) -> (Fpath.to_string n, Some (Fpath.to_string f)))
+        in
+        let bin = process bin
+        and sbin = process sbin
+        and share = process share
+        and share_root = process share_root
+        and etc = process etc
+        and doc = process doc
+        and man = process man in
+        Some
+          (Package.Install_file.v ~bin ~sbin ~share ~share_root ~etc ~doc ~man
+             ())
+end
+
 type full_name = Package.full_name
 
 (** Name and version of the binary package corresponding to a given package. *)
@@ -16,12 +89,15 @@ let ver = Package.ver
 let package t = t
 let to_string = Package.to_string
 
-let generate_opam_file original_name pure_binary archive_path ocaml_version =
+let generate_opam_file original_name bname pure_binary archive_path install
+    ocaml_version =
   let conflicts = if pure_binary then None else Some [ original_name ] in
-  Package.Opam_file.v
-    ~install:[ [ "cp"; "-pPR"; "."; "%{prefix}%" ] ]
+  let install =
+    if install then Some [ [ "cp"; "-pPR"; "."; "%{prefix}%" ] ] else None
+  in
+  Package.Opam_file.v ?install
     ~depends:[ ("ocaml", Some ("=", Ocaml_version.to_string ocaml_version)) ]
-    ?conflicts ~url:archive_path
+    ?conflicts ~url:archive_path ~opam_version:"2.0" ~pkg_name:(name bname)
 
 let should_remove = Fpath.(is_prefix (v "lib"))
 
@@ -43,10 +119,11 @@ let make_binary_package opam_opts ~ocaml_version sandbox archive_path bname
   let* paths =
     paths
     |> Result.List.filter_map (process_path prefix)
-    >>| List.map Fpath.to_string >>| String.concat ~sep:"\n"
+    >>| List.map Fpath.to_string
   in
+  let tar_input = paths |> String.concat ~sep:"\n" in
   OS.Cmd.(
-    in_string paths
+    in_string tar_input
     |> run_in
          Cmd.(
            v "tar" % "czf" % p archive_path % "-C"
@@ -54,9 +131,11 @@ let make_binary_package opam_opts ~ocaml_version sandbox archive_path bname
            % "-T" % "-"))
   >>= fun () ->
   OS.File.exists archive_path >>= fun archive_created ->
+  let install = Binary_install_file.from_file_list query_name paths in
+  let opam_file =
+    generate_opam_file query_name bname pure_binary archive_path
+      (Option.is_none install) ocaml_version
+  in
   if not archive_created then
     Error (`Msg "Couldn't generate the package archive for unknown reason.")
-  else
-    Ok
-      (generate_opam_file query_name pure_binary archive_path ocaml_version
-         ~opam_version:"2.0" ~pkg_name:(name bname))
+  else Ok (install, opam_file)

--- a/src/lib/binary_package.ml
+++ b/src/lib/binary_package.ml
@@ -3,23 +3,22 @@ open Result.Syntax
 open Astring
 open Bos
 
-type t = { name : string; ver : string }
+type full_name = Package.full_name
 
 (** Name and version of the binary package corresponding to a given package. *)
 let binary_name ~ocaml_version ~name ~ver ~pure_binary =
   let name = if pure_binary then name else name ^ "+bin+platform" in
-  let ocaml_version = Ocaml_version.to_string ocaml_version in
-  { name; ver = ver ^ "-ocaml" ^ ocaml_version }
+  let ver = ver ^ "-ocaml" ^ Ocaml_version.to_string ocaml_version in
+  Package.v ~name ~ver
 
-let name_to_string { name; ver } = name ^ "." ^ ver
-let name { name; ver = _ } = name
-
-let has_binary_package repo { name; ver } =
-  Repo.has_pkg (Binary_repo.repo repo) ~pkg:name ~ver
+let name = Package.name
+let ver = Package.ver
+let package t = t
+let to_string = Package.to_string
 
 let generate_opam_file original_name pure_binary archive_path ocaml_version =
   let conflicts = if pure_binary then None else Some [ original_name ] in
-  Repo.Opam_file.v
+  Package.Opam_file.v
     ~install:[ [ "cp"; "-pPR"; "."; "%{prefix}%" ] ]
     ~depends:[ ("ocaml", Some ("=", Ocaml_version.to_string ocaml_version)) ]
     ?conflicts ~url:archive_path
@@ -37,12 +36,9 @@ let process_path prefix path =
 
 (** Binary is already in the sandbox. Add this binary as a package in the local
     repo *)
-let make_binary_package opam_opts ~ocaml_version sandbox repo
-    ({ name; ver } as bname) ~name:query_name ~pure_binary =
+let make_binary_package opam_opts ~ocaml_version sandbox archive_path bname
+    ~name:query_name ~pure_binary =
   let prefix = Sandbox_switch.switch_path_prefix sandbox in
-  let archive_path =
-    Binary_repo.archive_path repo ~unique_name:(name_to_string bname ^ ".tar.gz")
-  in
   Sandbox_switch.list_files opam_opts sandbox ~pkg:query_name >>= fun paths ->
   let* paths =
     paths
@@ -61,7 +57,6 @@ let make_binary_package opam_opts ~ocaml_version sandbox repo
   if not archive_created then
     Error (`Msg "Couldn't generate the package archive for unknown reason.")
   else
-    let opam =
-      generate_opam_file query_name pure_binary archive_path ocaml_version
-    in
-    Repo.add_package opam_opts (Binary_repo.repo repo) ~pkg:name ~ver opam
+    Ok
+      (generate_opam_file query_name pure_binary archive_path ocaml_version
+         ~opam_version:"2.0" ~pkg_name:(name bname))

--- a/src/lib/binary_package.ml
+++ b/src/lib/binary_package.ml
@@ -73,7 +73,7 @@ module Binary_install_file = struct
         and man = process man in
         Some
           (Package.Install_file.v ~bin ~sbin ~share ~share_root ~etc ~doc ~man
-             ())
+             ~pkg_name ())
 end
 
 type full_name = Package.full_name
@@ -96,8 +96,8 @@ let generate_opam_file original_name bname pure_binary archive_path install
     if install then Some [ [ "cp"; "-pPR"; "."; "%{prefix}%" ] ] else None
   in
   Package.Opam_file.v ?install
-    ~depends:[ ("ocaml", Some ("=", Ocaml_version.to_string ocaml_version)) ]
-    ?conflicts ~url:archive_path ~opam_version:"2.0" ~pkg_name:(name bname)
+    ~depends:[ ("ocaml", [ (`Eq, Ocaml_version.to_string ocaml_version) ]) ]
+    ?conflicts ~url:archive_path ~opam_version:"2.0" ~pkg_name:(name bname) ()
 
 let should_remove = Fpath.(is_prefix (v "lib"))
 

--- a/src/lib/binary_package.ml
+++ b/src/lib/binary_package.ml
@@ -97,7 +97,7 @@ let generate_opam_file original_name bname pure_binary archive_path install
   in
   Package.Opam_file.v ?install
     ~depends:[ ("ocaml", [ (`Eq, Ocaml_version.to_string ocaml_version) ]) ]
-    ?conflicts ~url:archive_path ~opam_version:"2.0" ~pkg_name:(name bname) ()
+    ?conflicts ~url:archive_path ~pkg_name:(name bname) ()
 
 let should_remove = Fpath.(is_prefix (v "lib"))
 

--- a/src/lib/binary_package.mli
+++ b/src/lib/binary_package.mli
@@ -25,6 +25,6 @@ val make_binary_package :
   full_name ->
   name:string ->
   pure_binary:bool ->
-  (Package.Install_file.t option * Package.Opam_file.t, 'e) Result.or_msg
+  (Package.Install_file.t * Package.Opam_file.t, 'e) Result.or_msg
 (** Make a binary package from the result of installing a package in the sandbox
     switch. *)

--- a/src/lib/binary_package.mli
+++ b/src/lib/binary_package.mli
@@ -3,29 +3,28 @@
 
 open! Import
 
-type t
+type full_name
 
 val binary_name :
   ocaml_version:Ocaml_version.t ->
   name:string ->
   ver:string ->
   pure_binary:bool ->
-  t
+  full_name
 
-val name_to_string : t -> string
-val name : t -> string
-
-val has_binary_package : Binary_repo.t -> t -> bool
-(** Whether the repository already contain the binary version of a package. *)
+val to_string : full_name -> string
+val name : full_name -> string
+val ver : full_name -> string
+val package : full_name -> Package.full_name
 
 val make_binary_package :
   Opam.GlobalOpts.t ->
   ocaml_version:Ocaml_version.t ->
   Sandbox_switch.t ->
-  Binary_repo.t ->
-  t ->
+  Fpath.t ->
+  full_name ->
   name:string ->
   pure_binary:bool ->
-  (unit, 'e) Result.or_msg
+  (Package.Opam_file.t, 'e) Result.or_msg
 (** Make a binary package from the result of installing a package in the sandbox
     switch. *)

--- a/src/lib/binary_package.mli
+++ b/src/lib/binary_package.mli
@@ -25,6 +25,6 @@ val make_binary_package :
   full_name ->
   name:string ->
   pure_binary:bool ->
-  (Package.Opam_file.t, 'e) Result.or_msg
+  (Package.Install_file.t option * Package.Opam_file.t, 'e) Result.or_msg
 (** Make a binary package from the result of installing a package in the sandbox
     switch. *)

--- a/src/lib/binary_repo.ml
+++ b/src/lib/binary_repo.ml
@@ -24,8 +24,10 @@ let add_binary_package opam_opts ~ocaml_version sandbox repo bpack
   let archive_path =
     archive_path repo ~unique_name:(Binary_package.to_string bpack ^ ".tar.gz")
   in
-  let* opam =
+  let* install, opam =
     Binary_package.make_binary_package opam_opts ~ocaml_version sandbox
       archive_path bpack ~name:query_name ~pure_binary
   in
-  Repo.add_package opam_opts repo.repo (Binary_package.package bpack) opam
+  Repo.add_package opam_opts repo.repo
+    (Binary_package.package bpack)
+    install opam

--- a/src/lib/binary_repo.ml
+++ b/src/lib/binary_repo.ml
@@ -13,3 +13,19 @@ let init opam_opts base_path =
 
 let repo t = t.repo
 let archive_path t ~unique_name = Fpath.( / ) t.archive unique_name
+
+let has_binary_pkg repo pack =
+  Repo.has_pkg repo.repo (Binary_package.package pack)
+
+(** Binary is already in the sandbox. Add this binary as a package in the local
+    repo *)
+let add_binary_package opam_opts ~ocaml_version sandbox repo bpack
+    ~name:query_name ~pure_binary =
+  let archive_path =
+    archive_path repo ~unique_name:(Binary_package.to_string bpack ^ ".tar.gz")
+  in
+  let* opam =
+    Binary_package.make_binary_package opam_opts ~ocaml_version sandbox
+      archive_path bpack ~name:query_name ~pure_binary
+  in
+  Repo.add_package opam_opts repo.repo (Binary_package.package bpack) opam

--- a/src/lib/binary_repo.mli
+++ b/src/lib/binary_repo.mli
@@ -10,3 +10,18 @@ val repo : t -> Repo.t
 
 val archive_path : t -> unique_name:string -> Fpath.t
 (** A path to write an archve to. *)
+
+val has_binary_pkg : t -> Binary_package.full_name -> bool
+(** Whether the repository already contain the binary version of a package. *)
+
+val add_binary_package :
+  Opam.GlobalOpts.t ->
+  ocaml_version:Ocaml_version.t ->
+  Sandbox_switch.t ->
+  t ->
+  Binary_package.full_name ->
+  name:string ->
+  pure_binary:bool ->
+  (unit, 'e) Result.or_msg
+(** Make a binary package from the result of installing a package in the sandbox
+    switch. *)

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -1,4 +1,14 @@
 (library
  (name platform)
- (foreign_stubs (language c) (names signal_stubs))
- (libraries astring angstrom ocaml-version bos.setup ANSITerminal lwt lwt.unix))
+ (foreign_stubs
+  (language c)
+  (names signal_stubs))
+ (libraries
+  astring
+  angstrom
+  ocaml-version
+  bos.setup
+  ANSITerminal
+  lwt
+  lwt.unix
+  opam-file-format))

--- a/src/lib/package.ml
+++ b/src/lib/package.ml
@@ -8,11 +8,7 @@ let to_string { name; ver } = name ^ "." ^ ver
 let name { name; ver = _ } = name
 let ver { name = _; ver } = ver
 
-module Opam_file = struct
-  type t = unit Fmt.t
-  type cmd = string list
-  type dep = string * (string * string) option
-
+module FilesGenerator = struct
   let fpf = Format.fprintf
   let field ppf name pp_a a = fpf ppf "%s @[<v>%a@]@\n" name pp_a a
 
@@ -26,20 +22,85 @@ module Opam_file = struct
 
   let gen_string ppf s = fpf ppf "%S" s
 
-  let gen_dep_filter ppf = function
-    | Some (op, cons) -> fpf ppf "{%s %S}" op cons
+  let gen_option pp_a ppf = function
+    | Some op -> fpf ppf " { %a }" pp_a op
     | None -> ()
 
-  let gen_dep ppf (name, filter) = fpf ppf "%S%a" name gen_dep_filter filter
+  let gen_field_with_opt f_pp_a opt_pp_a ppf (s, opt) =
+    fpf ppf "%a%a" f_pp_a s (gen_option opt_pp_a) opt
+end
+
+module Opam_file = struct
+  open FilesGenerator
+
+  type t = unit Fmt.t
+  type cmd = string list
+  type dep = string * (string * string) option
+
+  let gen_dep =
+    let gen_constraint ppf (op, cons) = fpf ppf "%s %S" op cons in
+    gen_list (gen_field_with_opt gen_string gen_constraint)
+
   let gen_url ppf url = fpf ppf "{@ src: %S@ }" (Fpath.to_string url)
 
   let v ?install ?depends ?conflicts ?url ~opam_version ~pkg_name ppf () =
     field ppf "opam-version:" gen_string opam_version;
     field ppf "name:" gen_string pkg_name;
     field_opt ppf "install:" (gen_list (gen_list gen_string)) install;
-    field_opt ppf "depends:" (gen_list gen_dep) depends;
+    field_opt ppf "depends:" gen_dep depends;
     field_opt ppf "conflicts:" (gen_list gen_string) conflicts;
     field_opt ppf "url" gen_url url
+
+  let fprintf t = t
+end
+
+module Install_file = struct
+  open FilesGenerator
+
+  type t = unit Fmt.t
+
+  let v ?lib ?lib_root ?libexec ?libexec_root ?bin ?sbin ?toplevel ?share
+      ?share_root ?etc ?doc ?stublibs ?man ?misc () =
+    let l =
+      [
+        ("lib:", lib);
+        ("lib_root:", lib_root);
+        ("libexec:", libexec);
+        ("libexec_root:", libexec_root);
+        ("bin:", bin);
+        ("sbin:", sbin);
+        ("toplevel:", toplevel);
+        ("share:", share);
+        ("share_root:", share_root);
+        ("etc:", etc);
+        ("doc:", doc);
+        ("stublibs:", stublibs);
+        ("man:", man);
+        ("misc:", misc);
+      ]
+    in
+    fun ppf () ->
+      List.iter
+        (fun (f, p) ->
+          field_opt ppf f
+            (gen_list (gen_field_with_opt gen_string gen_string))
+            p)
+        l
+
+  (* field_opt ppf "lib:" (gen_list gen_string) lib; *)
+  (* field_opt ppf "lib_root:" (gen_list gen_string) lib_root; *)
+  (* field_opt ppf "libexec:" (gen_list gen_string) libexec; *)
+  (* field_opt ppf "libexec_root:" (gen_list gen_string) libexec_root; *)
+  (* field_opt ppf "bin:" (gen_list gen_string) bin; *)
+  (* field_opt ppf "sbin:" (gen_list gen_string) sbin; *)
+  (* field_opt ppf "toplevel:" (gen_list gen_string) toplevel; *)
+  (* field_opt ppf "share:" (gen_list gen_string) share; *)
+  (* field_opt ppf "share_root:" (gen_list gen_string) share_root; *)
+  (* field_opt ppf "etc:" (gen_list gen_string) etc; *)
+  (* field_opt ppf "doc:" (gen_list gen_string) doc; *)
+  (* field_opt ppf "stublibs:" (gen_list gen_string) stublibs; *)
+  (* field_opt ppf "man:" (gen_list gen_string) man; *)
+  (* field_opt ppf "misc:" (gen_list gen_string) misc *)
 
   let fprintf t = t
 end

--- a/src/lib/package.ml
+++ b/src/lib/package.ml
@@ -85,39 +85,16 @@ module Install_file = struct
 
   type t = OpamParserTypes.FullPos.opamfile
 
-  let v ?lib ?lib_root ?libexec ?libexec_root ?bin ?sbin ?toplevel ?share
-      ?share_root ?etc ?doc ?stublibs ?man ?misc ~pkg_name () =
+  let v classified_files ~pkg_name =
     let of_option o = match o with None -> [] | Some a -> [ string a ] in
-    let l =
-      [
-        ("lib:", lib);
-        ("lib_root:", lib_root);
-        ("libexec:", libexec);
-        ("libexec_root:", libexec_root);
-        ("bin:", bin);
-        ("sbin:", sbin);
-        ("toplevel:", toplevel);
-        ("share:", share);
-        ("share_root:", share_root);
-        ("etc:", etc);
-        ("doc:", doc);
-        ("stublibs:", stublibs);
-        ("man:", man);
-        ("misc:", misc);
-      ]
-    in
-
-    let file_name = pkg_name ^ ".install"
-    and file_contents =
-      List.map
-        (fun (f, v) ->
+    let file_contents =
+      String.Map.fold
+        (fun f v l ->
           variable f
-            (list
-               (List.map
-                  (fun (p, c) -> option (string p) (of_option c))
-                  (Option.value ~default:[] v))))
-        l
-    in
+            (list (List.map (fun (p, c) -> option (string p) (of_option c)) v))
+          :: l)
+        classified_files []
+    and file_name = pkg_name ^ ".install" in
     { OpamParserTypes.FullPos.file_contents; file_name }
 
   let to_string t = OpamPrinter.FullPos.opamfile t

--- a/src/lib/package.ml
+++ b/src/lib/package.ml
@@ -32,7 +32,8 @@ module Opam_file = struct
   let option v l = with_pos @@ OpamParserTypes.FullPos.Option (v, with_pos l)
   let prefix_relop p v = with_pos @@ Prefix_relop (with_pos p, v)
 
-  let v ?install ?depends ?conflicts ?url ~opam_version ~pkg_name () =
+  let v ?install ?depends ?conflicts ?url ~pkg_name () =
+    let opam_version = "2.0" in
     let file_name = "opam" in
     let opam_version = variable "opam-version" (string opam_version)
     and name = variable "name" (string pkg_name)

--- a/src/lib/package.ml
+++ b/src/lib/package.ml
@@ -1,0 +1,45 @@
+open! Import
+open Astring
+
+type full_name = { name : string; ver : string }
+
+let v ~name ~ver = { name; ver }
+let to_string { name; ver } = name ^ "." ^ ver
+let name { name; ver = _ } = name
+let ver { name = _; ver } = ver
+
+module Opam_file = struct
+  type t = unit Fmt.t
+  type cmd = string list
+  type dep = string * (string * string) option
+
+  let fpf = Format.fprintf
+  let field ppf name pp_a a = fpf ppf "%s @[<v>%a@]@\n" name pp_a a
+
+  let field_opt ppf name pp_a = function
+    | Some a -> field ppf name pp_a a
+    | None -> ()
+
+  let gen_list pp_a ppf lst =
+    let pp_a ppf a = fpf ppf "@[<hov>%a@]" pp_a a in
+    fpf ppf "[@ %a@ ]" (Format.pp_print_list pp_a) lst
+
+  let gen_string ppf s = fpf ppf "%S" s
+
+  let gen_dep_filter ppf = function
+    | Some (op, cons) -> fpf ppf "{%s %S}" op cons
+    | None -> ()
+
+  let gen_dep ppf (name, filter) = fpf ppf "%S%a" name gen_dep_filter filter
+  let gen_url ppf url = fpf ppf "{@ src: %S@ }" (Fpath.to_string url)
+
+  let v ?install ?depends ?conflicts ?url ~opam_version ~pkg_name ppf () =
+    field ppf "opam-version:" gen_string opam_version;
+    field ppf "name:" gen_string pkg_name;
+    field_opt ppf "install:" (gen_list (gen_list gen_string)) install;
+    field_opt ppf "depends:" (gen_list gen_dep) depends;
+    field_opt ppf "conflicts:" (gen_list gen_string) conflicts;
+    field_opt ppf "url" gen_url url
+
+  let fprintf t = t
+end

--- a/src/lib/package.mli
+++ b/src/lib/package.mli
@@ -5,40 +5,13 @@ val to_string : full_name -> string
 val name : full_name -> string
 val ver : full_name -> string
 
-module FilesGenerator : sig
-  val field :
-    Format.formatter -> string -> (Format.formatter -> 'a -> unit) -> 'a -> unit
-
-  val field_opt :
-    Format.formatter ->
-    string ->
-    (Format.formatter -> 'a -> unit) ->
-    'a option ->
-    unit
-
-  val gen_list :
-    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a list -> unit
-
-  val gen_string : Format.formatter -> string -> unit
-
-  val gen_option :
-    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a option -> unit
-
-  val gen_field_with_opt :
-    (Format.formatter -> 'a -> unit) ->
-    (Format.formatter -> 'b -> unit) ->
-    Format.formatter ->
-    'a * 'b option ->
-    unit
-end
-
 module Opam_file : sig
   (** Package description. *)
 
   type t
   type cmd = string list
 
-  type dep = string * (string * string) option
+  type dep = string * ([ `Eq | `Geq | `Gt | `Leq | `Lt | `Neq ] * string) list
   (** [name * (operator * constraint) option]. *)
 
   val v :
@@ -48,9 +21,10 @@ module Opam_file : sig
     ?url:Fpath.t ->
     opam_version:string ->
     pkg_name:string ->
+    unit ->
     t
 
-  val fprintf : t -> unit Fmt.t
+  val to_string : t -> string
 end
 
 module Install_file : sig
@@ -71,8 +45,9 @@ module Install_file : sig
     ?stublibs:(string * string option) list ->
     ?man:(string * string option) list ->
     ?misc:(string * string option) list ->
+    pkg_name:string ->
     unit ->
     t
 
-  val fprintf : t -> unit Fmt.t
+  val to_string : t -> string
 end

--- a/src/lib/package.mli
+++ b/src/lib/package.mli
@@ -1,3 +1,5 @@
+open Astring
+
 type full_name
 
 val v : name:string -> ver:string -> full_name
@@ -29,24 +31,6 @@ end
 module Install_file : sig
   type t
 
-  val v :
-    ?lib:(string * string option) list ->
-    ?lib_root:(string * string option) list ->
-    ?libexec:(string * string option) list ->
-    ?libexec_root:(string * string option) list ->
-    ?bin:(string * string option) list ->
-    ?sbin:(string * string option) list ->
-    ?toplevel:(string * string option) list ->
-    ?share:(string * string option) list ->
-    ?share_root:(string * string option) list ->
-    ?etc:(string * string option) list ->
-    ?doc:(string * string option) list ->
-    ?stublibs:(string * string option) list ->
-    ?man:(string * string option) list ->
-    ?misc:(string * string option) list ->
-    pkg_name:string ->
-    unit ->
-    t
-
+  val v : (string * string option) list String.Map.t -> pkg_name:string -> t
   val to_string : t -> string
 end

--- a/src/lib/package.mli
+++ b/src/lib/package.mli
@@ -5,6 +5,33 @@ val to_string : full_name -> string
 val name : full_name -> string
 val ver : full_name -> string
 
+module FilesGenerator : sig
+  val field :
+    Format.formatter -> string -> (Format.formatter -> 'a -> unit) -> 'a -> unit
+
+  val field_opt :
+    Format.formatter ->
+    string ->
+    (Format.formatter -> 'a -> unit) ->
+    'a option ->
+    unit
+
+  val gen_list :
+    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a list -> unit
+
+  val gen_string : Format.formatter -> string -> unit
+
+  val gen_option :
+    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a option -> unit
+
+  val gen_field_with_opt :
+    (Format.formatter -> 'a -> unit) ->
+    (Format.formatter -> 'b -> unit) ->
+    Format.formatter ->
+    'a * 'b option ->
+    unit
+end
+
 module Opam_file : sig
   (** Package description. *)
 
@@ -21,6 +48,30 @@ module Opam_file : sig
     ?url:Fpath.t ->
     opam_version:string ->
     pkg_name:string ->
+    t
+
+  val fprintf : t -> unit Fmt.t
+end
+
+module Install_file : sig
+  type t
+
+  val v :
+    ?lib:(string * string option) list ->
+    ?lib_root:(string * string option) list ->
+    ?libexec:(string * string option) list ->
+    ?libexec_root:(string * string option) list ->
+    ?bin:(string * string option) list ->
+    ?sbin:(string * string option) list ->
+    ?toplevel:(string * string option) list ->
+    ?share:(string * string option) list ->
+    ?share_root:(string * string option) list ->
+    ?etc:(string * string option) list ->
+    ?doc:(string * string option) list ->
+    ?stublibs:(string * string option) list ->
+    ?man:(string * string option) list ->
+    ?misc:(string * string option) list ->
+    unit ->
     t
 
   val fprintf : t -> unit Fmt.t

--- a/src/lib/package.mli
+++ b/src/lib/package.mli
@@ -19,7 +19,6 @@ module Opam_file : sig
     ?depends:dep list ->
     ?conflicts:string list ->
     ?url:Fpath.t ->
-    opam_version:string ->
     pkg_name:string ->
     unit ->
     t

--- a/src/lib/package.mli
+++ b/src/lib/package.mli
@@ -1,0 +1,27 @@
+type full_name
+
+val v : name:string -> ver:string -> full_name
+val to_string : full_name -> string
+val name : full_name -> string
+val ver : full_name -> string
+
+module Opam_file : sig
+  (** Package description. *)
+
+  type t
+  type cmd = string list
+
+  type dep = string * (string * string) option
+  (** [name * (operator * constraint) option]. *)
+
+  val v :
+    ?install:cmd list ->
+    ?depends:dep list ->
+    ?conflicts:string list ->
+    ?url:Fpath.t ->
+    opam_version:string ->
+    pkg_name:string ->
+    t
+
+  val fprintf : t -> unit Fmt.t
+end

--- a/src/lib/repo.ml
+++ b/src/lib/repo.ml
@@ -45,17 +45,16 @@ let add_package opam_opts t pkg install opam =
     | Some install ->
         OS.File.writef
           Fpath.(repo_path / "files" / (Package.name pkg ^ ".install"))
-          "%a"
-          (Package.Install_file.fprintf install)
-          ()
+          "%s"
+          (Package.Install_file.to_string install)
   in
   let* () =
     OS.File.writef
       Fpath.(repo_path / "opam")
-      "%a"
-      (Package.Opam_file.fprintf opam)
-      ()
+      "%s"
+      (Package.Opam_file.to_string opam)
   in
+
   Opam.update opam_opts [ t.name ]
 
 let with_repo_enabled opam_opts t f =

--- a/src/lib/repo.ml
+++ b/src/lib/repo.ml
@@ -40,13 +40,10 @@ let add_package opam_opts t pkg install opam =
   let* _ = OS.Dir.create repo_path in
   let* _ = OS.Dir.create Fpath.(repo_path / "files") in
   let* () =
-    match install with
-    | None -> Ok ()
-    | Some install ->
-        OS.File.writef
-          Fpath.(repo_path / "files" / (Package.name pkg ^ ".install"))
-          "%s"
-          (Package.Install_file.to_string install)
+    OS.File.writef
+      Fpath.(repo_path / "files" / (Package.name pkg ^ ".install"))
+      "%s"
+      (Package.Install_file.to_string install)
   in
   let* () =
     OS.File.writef

--- a/src/lib/repo.ml
+++ b/src/lib/repo.ml
@@ -34,10 +34,21 @@ let has_pkg t pkg =
   | Ok r -> r
   | Error _ -> false
 
-let add_package opam_opts t pkg opam =
+let add_package opam_opts t pkg install opam =
   let open Result.Syntax in
   let repo_path = repo_path_of_pkg t pkg in
   let* _ = OS.Dir.create repo_path in
+  let* _ = OS.Dir.create Fpath.(repo_path / "files") in
+  let* () =
+    match install with
+    | None -> Ok ()
+    | Some install ->
+        OS.File.writef
+          Fpath.(repo_path / "files" / (Package.name pkg ^ ".install"))
+          "%a"
+          (Package.Install_file.fprintf install)
+          ()
+  in
   let* () =
     OS.File.writef
       Fpath.(repo_path / "opam")

--- a/src/lib/repo.ml
+++ b/src/lib/repo.ml
@@ -1,40 +1,6 @@
 open Bos
 open Import
 
-module Opam_file = struct
-  type t = opam_version:string -> pkg_name:string -> unit Fmt.t
-  type cmd = string list
-  type dep = string * (string * string) option
-
-  let fpf = Format.fprintf
-  let field ppf name pp_a a = fpf ppf "%s @[<v>%a@]@\n" name pp_a a
-
-  let field_opt ppf name pp_a = function
-    | Some a -> field ppf name pp_a a
-    | None -> ()
-
-  let gen_list pp_a ppf lst =
-    let pp_a ppf a = fpf ppf "@[<hov>%a@]" pp_a a in
-    fpf ppf "[@ %a@ ]" (Format.pp_print_list pp_a) lst
-
-  let gen_string ppf s = fpf ppf "%S" s
-
-  let gen_dep_filter ppf = function
-    | Some (op, cons) -> fpf ppf "{%s %S}" op cons
-    | None -> ()
-
-  let gen_dep ppf (name, filter) = fpf ppf "%S%a" name gen_dep_filter filter
-  let gen_url ppf url = fpf ppf "{@ src: %S@ }" (Fpath.to_string url)
-
-  let v ?install ?depends ?conflicts ?url ~opam_version ~pkg_name ppf () =
-    field ppf "opam-version:" gen_string opam_version;
-    field ppf "name:" gen_string pkg_name;
-    field_opt ppf "install:" (gen_list (gen_list gen_string)) install;
-    field_opt ppf "depends:" (gen_list gen_dep) depends;
-    field_opt ppf "conflicts:" (gen_list gen_string) conflicts;
-    field_opt ppf "url" gen_url url
-end
-
 type t = { name : string; path : Fpath.t }
 
 let opam_version = "2.0"
@@ -60,23 +26,23 @@ let init opam_opts ~name path =
     let* () = Opam.Repository.add opam_opts ~url:(Fpath.to_string path) name in
     Ok repo
 
-let repo_path_of_pkg t ~pkg ~ver =
-  Fpath.(t.path / "packages" / pkg / (pkg ^ "." ^ ver))
+let repo_path_of_pkg t pkg =
+  Fpath.(t.path / "packages" / Package.name pkg / Package.to_string pkg)
 
-let has_pkg t ~pkg ~ver =
-  match OS.Dir.exists (repo_path_of_pkg t ~pkg ~ver) with
+let has_pkg t pkg =
+  match OS.Dir.exists (repo_path_of_pkg t pkg) with
   | Ok r -> r
   | Error _ -> false
 
-let add_package opam_opts t ~pkg ~ver opam =
+let add_package opam_opts t pkg opam =
   let open Result.Syntax in
-  let repo_path = repo_path_of_pkg t ~pkg ~ver in
+  let repo_path = repo_path_of_pkg t pkg in
   let* _ = OS.Dir.create repo_path in
   let* () =
     OS.File.writef
       Fpath.(repo_path / "opam")
       "%a"
-      (opam ~opam_version ~pkg_name:pkg)
+      (Package.Opam_file.fprintf opam)
       ()
   in
   Opam.update opam_opts [ t.name ]

--- a/src/lib/repo.mli
+++ b/src/lib/repo.mli
@@ -4,23 +4,6 @@
 open Bos
 open Import
 
-module Opam_file : sig
-  (** Package description. *)
-
-  type t
-  type cmd = string list
-
-  type dep = string * (string * string) option
-  (** [name * (operator * constraint) option]. *)
-
-  val v :
-    ?install:cmd list ->
-    ?depends:dep list ->
-    ?conflicts:string list ->
-    ?url:Fpath.t ->
-    t
-end
-
 type t
 
 val init : Opam.GlobalOpts.t -> name:string -> Fpath.t -> (t, 'e) Result.or_msg
@@ -28,15 +11,14 @@ val init : Opam.GlobalOpts.t -> name:string -> Fpath.t -> (t, 'e) Result.or_msg
     doesn't exist, it is initialized and registered into Opam. The repository
     isn't added to the selection of any switch. *)
 
-val has_pkg : t -> pkg:string -> ver:string -> bool
+val has_pkg : t -> Package.full_name -> bool
 (** Whether a specific version of a package exists in the repository. *)
 
 val add_package :
   Opam.GlobalOpts.t ->
   t ->
-  pkg:string ->
-  ver:string ->
-  Opam_file.t ->
+  Package.full_name ->
+  Package.Opam_file.t ->
   (unit, 'e) OS.result
 
 val with_repo_enabled :

--- a/src/lib/repo.mli
+++ b/src/lib/repo.mli
@@ -18,7 +18,7 @@ val add_package :
   Opam.GlobalOpts.t ->
   t ->
   Package.full_name ->
-  Package.Install_file.t option ->
+  Package.Install_file.t ->
   Package.Opam_file.t ->
   (unit, 'e) OS.result
 

--- a/src/lib/repo.mli
+++ b/src/lib/repo.mli
@@ -18,6 +18,7 @@ val add_package :
   Opam.GlobalOpts.t ->
   t ->
   Package.full_name ->
+  Package.Install_file.t option ->
   Package.Opam_file.t ->
   (unit, 'e) OS.result
 

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -88,7 +88,7 @@ let make_binary_package opam_opts ~ocaml_version sandbox repo bname tool =
   let { name; pure_binary; _ } = tool in
   Sandbox_switch.install opam_opts sandbox ~pkg:(tool.name, tool.version)
   >>= fun () ->
-  Binary_package.make_binary_package opam_opts ~ocaml_version sandbox repo bname
+  Binary_repo.add_binary_package opam_opts ~ocaml_version sandbox repo bname
     ~name ~pure_binary
 
 let install opam_opts tools =
@@ -122,12 +122,12 @@ let install opam_opts tools =
             let+ bname = best_version_of_tool opam_opts ocaml_version tool in
             Logs.app (fun m ->
                 m "  -> %s will be installed as %s" tool.name
-                  (Binary_package.name_to_string bname));
+                  (Binary_package.to_string bname));
             let to_build =
-              if Binary_package.has_binary_package repo bname then to_build
+              if Binary_repo.has_binary_pkg repo bname then to_build
               else (tool, bname) :: to_build
             in
-            (to_build, Binary_package.name_to_string bname :: to_install))
+            (to_build, Binary_package.to_string bname :: to_install))
       ([], []) tools
   in
   (match tools_to_build with


### PR DESCRIPTION
This PR implements @rjbou #48 suggestion of using an `install` file instead of the `install` instruction in the `opam` file.

This is good for few things:
- It is faster as `opam 2.1` do not re-scan the entire folder twice
- It is more cross-compatible as the build instruction may rely on the `cp` presence and syntax
- It install files in more logical places given the package name (see after).

The first commit of this PR is only a refactoring commit,  introducing a `Package` module. The second commit introduces the functionality.

If an installed file of a tool do not belong to any of the [installation location](https://opam.ocaml.org/doc/Manual.html#lt-pkgname-gt-install) offered by the `.install` file syntax, the tool is considered "incompatible" with `.install` file and the old build instruction is used.

It is worth noting that this PR changes a bit the organization of the packages that are installed with `.install` files, compared to what was before: before, things were installed as they are for the normal package (that is for instance, the `doc` part of `odoc+bin+platform` is installed in `doc/odoc/`), now the fact that the package name has changed is taken into account (the `doc` part of `odoc+bin+platform` is installed in `doc/odoc+bin+platform/`)

Note that currently, all tools are compatible with having a `.install` file instead of build instructions.