### PR TITLE
Add an `available` field to the repo.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- Add an `available` field with `arch` and `os-distribution` in the opam files
+  of the binary package (#74)
 - Improve logging behaviour in case of user interrupt (#80)
 - Use an install file instead of install instruction in binary package (#73)
 - Better logs, including few sliding lines of opam output when necessary (#57)

--- a/src/lib/binary_package.ml
+++ b/src/lib/binary_package.ml
@@ -54,12 +54,23 @@ let ver = Package.ver
 let package t = t
 let to_string = Package.to_string
 
-let generate_opam_file original_name bname pure_binary archive_path
+let generate_opam_file opam_opts original_name bname pure_binary archive_path
     ocaml_version =
   let conflicts = if pure_binary then None else Some [ original_name ] in
-  Package.Opam_file.v
-    ~depends:[ ("ocaml", [ (`Eq, Ocaml_version.to_string ocaml_version) ]) ]
-    ?conflicts ~url:archive_path ~pkg_name:(name bname) ()
+  let* arch = Opam.Config.Var.get opam_opts "arch" in
+  let+ os_distribution = Opam.Config.Var.get opam_opts "os-distribution" in
+  let available =
+    let open Package.Opam_file in
+    Package.Opam_file.Formula
+      ( `And,
+        Atom (`Eq, "arch", arch),
+        Atom (`Eq, "os-distribution", os_distribution) )
+  in
+  let depends =
+    [ ("ocaml", [ (`Eq, Ocaml_version.to_string ocaml_version) ]) ]
+  in
+  Package.Opam_file.v ~depends ~available ?conflicts ~url:archive_path
+    ~pkg_name:(name bname) ()
 
 let should_remove = Fpath.(is_prefix (v "lib"))
 
@@ -94,8 +105,9 @@ let make_binary_package opam_opts ~ocaml_version sandbox archive_path bname
   >>= fun () ->
   OS.File.exists archive_path >>= fun archive_created ->
   let install = Binary_install_file.from_file_list query_name paths in
-  let opam_file =
-    generate_opam_file query_name bname pure_binary archive_path ocaml_version
+  let* opam_file =
+    generate_opam_file opam_opts query_name bname pure_binary archive_path
+      ocaml_version
   in
   if not archive_created then
     Error (`Msg "Couldn't generate the package archive for unknown reason.")

--- a/src/lib/binary_package.ml
+++ b/src/lib/binary_package.ml
@@ -54,11 +54,9 @@ let ver = Package.ver
 let package t = t
 let to_string = Package.to_string
 
-let generate_opam_file opam_opts original_name bname pure_binary archive_path
-    ocaml_version =
+let generate_opam_file ~arch ~os_distribution original_name bname pure_binary
+    archive_path ocaml_version =
   let conflicts = if pure_binary then None else Some [ original_name ] in
-  let* arch = Opam.Config.Var.get opam_opts "arch" in
-  let+ os_distribution = Opam.Config.Var.get opam_opts "os-distribution" in
   let available =
     let open Package.Opam_file in
     Package.Opam_file.Formula
@@ -105,9 +103,11 @@ let make_binary_package opam_opts ~ocaml_version sandbox archive_path bname
   >>= fun () ->
   OS.File.exists archive_path >>= fun archive_created ->
   let install = Binary_install_file.from_file_list query_name paths in
-  let* opam_file =
-    generate_opam_file opam_opts query_name bname pure_binary archive_path
-      ocaml_version
+  let* arch = Opam.Config.Var.get opam_opts "arch" in
+  let* os_distribution = Opam.Config.Var.get opam_opts "os-distribution" in
+  let opam_file =
+    generate_opam_file ~arch ~os_distribution query_name bname pure_binary
+      archive_path ocaml_version
   in
   if not archive_created then
     Error (`Msg "Couldn't generate the package archive for unknown reason.")

--- a/src/lib/package.ml
+++ b/src/lib/package.ml
@@ -28,52 +28,52 @@ module Opam_file = struct
     with_pos @@ Section { section_kind; section_name; section_items }
 
   let string s = with_pos (String s)
+  let ident s = with_pos (Ident s)
   let list l = with_pos @@ List (with_pos l)
-  let option v l = with_pos @@ OpamParserTypes.FullPos.Option (v, with_pos l)
+  let option v l = with_pos @@ Option (v, with_pos l)
   let prefix_relop p v = with_pos @@ Prefix_relop (with_pos p, v)
 
-  let v ?install ?depends ?conflicts ?url ~pkg_name () =
+  type atom = [ `Eq | `Geq | `Gt | `Leq | `Lt | `Neq ] * string * string
+  type formula = Atom of atom | Formula of [ `And | `Or ] * formula * formula
+
+  let atom (op, a, b) = with_pos @@ Relop (with_pos op, ident a, string b)
+
+  let rec formula f =
+    match f with
+    | Atom a -> atom a
+    | Formula (relop, g, h) ->
+        with_pos @@ Logop (with_pos relop, formula g, formula h)
+
+  let v ?install ?depends ?conflicts ?available ?url ~pkg_name () =
     let opam_version = "2.0" in
     let file_name = "opam" in
-    let opam_version = variable "opam-version" (string opam_version)
-    and name = variable "name" (string pkg_name)
+    let opam_version = variable "opam-version" (string opam_version) in
+    let f_op_to_list e f = match e with None -> [] | Some l -> [ f l ] in
+    let name = variable "name" (string pkg_name)
+    and available =
+      f_op_to_list available @@ fun available ->
+      variable "available" (formula available)
     and install =
-      match install with
-      | None -> []
-      | Some install ->
-          [
-            variable "install"
-              (list (List.map (fun e -> list (List.map string e)) install));
-          ]
+      f_op_to_list install @@ fun install ->
+      variable "install"
+        (list (List.map (fun e -> list (List.map string e)) install))
     and depends =
-      match depends with
-      | None -> []
-      | Some depends ->
-          [
-            variable "depends"
-              (list
-                 (List.map
-                    (fun (p, c) ->
-                      option (string p)
-                        (List.map
-                           (fun (rel, cstr) -> prefix_relop rel (string cstr))
-                           c))
-                    depends));
-          ]
+      f_op_to_list depends @@ fun depends ->
+      let depend (p, c) =
+        option (string p)
+          (List.map (fun (rel, cstr) -> prefix_relop rel (string cstr)) c)
+      in
+      variable "depends" (list (List.map depend depends))
     and conflicts =
-      match conflicts with
-      | None -> []
-      | Some conflicts ->
-          [ variable "conflicts" (list (List.map string conflicts)) ]
+      f_op_to_list conflicts @@ fun conflicts ->
+      variable "conflicts" (list (List.map string conflicts))
     and url =
-      match url with
-      | None -> []
-      | Some url ->
-          let items = [ variable "src" (string (Fpath.to_string url)) ] in
-          [ section "url" None items ]
+      f_op_to_list url @@ fun url ->
+      let items = [ variable "src" (string (Fpath.to_string url)) ] in
+      section "url" None items
     in
     let file_contents =
-      [ opam_version; name ] @ install @ depends @ conflicts @ url
+      [ opam_version; name ] @ install @ depends @ available @ conflicts @ url
     in
     { OpamParserTypes.FullPos.file_contents; file_name }
 

--- a/src/lib/package.mli
+++ b/src/lib/package.mli
@@ -16,10 +16,16 @@ module Opam_file : sig
   type dep = string * ([ `Eq | `Geq | `Gt | `Leq | `Lt | `Neq ] * string) list
   (** [name * (operator * constraint) option]. *)
 
+  type atom = [ `Eq | `Geq | `Gt | `Leq | `Lt | `Neq ] * string * string
+  (** [operator * var_name * constraint] *)
+
+  type formula = Atom of atom | Formula of [ `And | `Or ] * formula * formula
+
   val v :
     ?install:cmd list ->
     ?depends:dep list ->
     ?conflicts:string list ->
+    ?available:formula ->
     ?url:Fpath.t ->
     pkg_name:string ->
     unit ->


### PR DESCRIPTION
The `available` field is filled with the `arch` condition and the `os-distribution` condition. This can be useful for the remote repo CI.

In any case, we might create one remote repo per (arch, os-distribution), and add only the repo we need, but it won't harm to have the `available` field additional check.