### PR TITLE
Use the opam library (for read_only operations)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -36,4 +36,5 @@
   base64
   astring
   bos
-  ppxlib))
+  (opam-state
+   (>= 2.1.2))))

--- a/platform.opam
+++ b/platform.opam
@@ -28,7 +28,7 @@ depends: [
   "base64"
   "astring"
   "bos"
-  "ppxlib"
+  "opam-state" {>= "2.1.2"}
   "odoc" {with-doc}
 ]
 build: [

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -142,4 +142,6 @@ let main () =
   in
   Stdlib.exit @@ Cmd.eval' (Cmd.v info term)
 
-let () = main ()
+let () =
+  Platform.Opam.Queries.init ();
+  main ()

--- a/src/lib/binary_package.ml
+++ b/src/lib/binary_package.ml
@@ -6,9 +6,9 @@ open Bos
 type t = { name : string; ver : string }
 
 (** Name and version of the binary package corresponding to a given package. *)
-let binary_name ~ocaml_version ~name ~ver ~pure_binary =
+let binary_name ~ocaml ~name ~ver ~pure_binary =
   let name = if pure_binary then name else name ^ "+bin+platform" in
-  let ocaml_version = Ocaml_version.to_string ocaml_version in
+  let ocaml_version = Opam.Conversions.version_of_pkg ocaml in
   { name; ver = ver ^ "-ocaml" ^ ocaml_version }
 
 let name_to_string { name; ver } = name ^ "." ^ ver
@@ -17,33 +17,41 @@ let name { name; ver = _ } = name
 let has_binary_package repo { name; ver } =
   Repo.has_pkg (Binary_repo.repo repo) ~pkg:name ~ver
 
-let generate_opam_file original_name pure_binary archive_path ocaml_version =
+let generate_opam_file original_name pure_binary archive_path ocaml =
   let conflicts = if pure_binary then None else Some [ original_name ] in
   Repo.Opam_file.v
     ~install:[ [ "cp"; "-pPR"; "."; "%{prefix}%" ] ]
-    ~depends:[ ("ocaml", Some ("=", Ocaml_version.to_string ocaml_version)) ]
+    ~depends:[ ("ocaml", Some ("=", Opam.Conversions.version_of_pkg ocaml)) ]
     ?conflicts ~url:archive_path
 
 let should_remove = Fpath.(is_prefix (v "lib"))
 
 let process_path prefix path =
-  let+ ex = Bos.OS.File.exists path in
-  if not ex then None
-  else
-    match Fpath.rem_prefix prefix path with
-    | None -> None
-    | Some path ->
-        if should_remove path then None else Some Fpath.(base prefix // path)
+  match Fpath.of_string path with
+  | Error (`Msg s) -> Error (`Msg s)
+  | Ok path -> (
+      let+ ex = Bos.OS.File.exists path in
+      if not ex then None
+      else
+        match Fpath.rem_prefix prefix path with
+        | None -> None
+        | Some path ->
+            if should_remove path then None
+            else Some Fpath.(base prefix // path))
 
 (** Binary is already in the sandbox. Add this binary as a package in the local
     repo *)
-let make_binary_package opam_opts ~ocaml_version sandbox repo
-    ({ name; ver } as bname) ~name:query_name ~pure_binary =
+let make_binary_package opam_opts ~ocaml sandbox repo ({ name; ver } as bname)
+    ~name:query_name ~pure_binary =
   let prefix = Sandbox_switch.switch_path_prefix sandbox in
   let archive_path =
     Binary_repo.archive_path repo ~unique_name:(name_to_string bname ^ ".tar.gz")
   in
-  Sandbox_switch.list_files opam_opts sandbox ~pkg:query_name >>= fun paths ->
+  Opam.Queries.(
+    with_switch_state
+      ~dir_name:(Sandbox_switch.get_sandbox_root sandbox)
+      (files_installed_by_pkg query_name))
+  >>= fun paths ->
   let* paths =
     paths
     |> Result.List.filter_map (process_path prefix)
@@ -61,7 +69,5 @@ let make_binary_package opam_opts ~ocaml_version sandbox repo
   if not archive_created then
     Error (`Msg "Couldn't generate the package archive for unknown reason.")
   else
-    let opam =
-      generate_opam_file query_name pure_binary archive_path ocaml_version
-    in
+    let opam = generate_opam_file query_name pure_binary archive_path ocaml in
     Repo.add_package opam_opts (Binary_repo.repo repo) ~pkg:name ~ver opam

--- a/src/lib/binary_package.mli
+++ b/src/lib/binary_package.mli
@@ -6,11 +6,7 @@ open! Import
 type t
 
 val binary_name :
-  ocaml_version:Ocaml_version.t ->
-  name:string ->
-  ver:string ->
-  pure_binary:bool ->
-  t
+  ocaml:OpamPackage.t -> name:string -> ver:string -> pure_binary:bool -> t
 
 val name_to_string : t -> string
 val name : t -> string
@@ -20,7 +16,7 @@ val has_binary_package : Binary_repo.t -> t -> bool
 
 val make_binary_package :
   Opam.GlobalOpts.t ->
-  ocaml_version:Ocaml_version.t ->
+  ocaml:OpamPackage.t ->
   Sandbox_switch.t ->
   Binary_repo.t ->
   t ->

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -1,3 +1,3 @@
 (library
  (name platform)
- (libraries astring angstrom ocaml-version bos.setup))
+ (libraries astring angstrom ocaml-version bos.setup opam-state))

--- a/src/lib/opam.mli
+++ b/src/lib/opam.mli
@@ -51,26 +51,46 @@ module Repository : sig
   val remove : GlobalOpts.t -> string -> (unit, [> `Msg of string ]) result
 end
 
-module Show : sig
-  val list_files :
-    GlobalOpts.t -> string -> (string list, [> `Msg of string ]) result
+module Queries : sig
+  val init : unit -> unit
 
-  val available_versions :
-    GlobalOpts.t -> string -> (string list, [> `Msg of string ]) result
+  val files_installed_by_pkg :
+    string ->
+    'lock OpamStateTypes.switch_state ->
+    (string list, [> `Msg of string ]) result
 
-  val installed_version :
-    GlobalOpts.t -> string -> (string option, [> `Msg of string ]) result
+  val get_pkg_universe :
+    'lock OpamStateTypes.switch_state -> OpamTypes.package_set lazy_t
+
+  val get_metadata_universe :
+    'lock OpamStateTypes.switch_state -> OpamFile.OPAM.t OpamTypes.package_map
+
+  val latest_version :
+    metadata_universe:OpamFile.OPAM.t OpamTypes.package_map ->
+    pkg_universe:OpamTypes.package_set ->
+    ocaml:OpamPackage.t ->
+    string ->
+    OpamPackage.t option
 
   val installed_versions :
-    GlobalOpts.t ->
-    string list ->
-    ((string * string option) list, 'a) Result.or_msg
+  string list ->
+    OpamTypes.switch_selections -> (string * OpamPackage.t option) list
 
-  val depends :
-    GlobalOpts.t -> string -> (string list, [> `Msg of string ]) result
+  val with_switch_state :
+    ?dir_name:Fpath.t ->
+    ([< OpamStateTypes.unlocked > `Lock_read `Lock_write ]
+     OpamStateTypes.switch_state ->
+    'a) ->
+    'a
 
-  val version :
-    GlobalOpts.t -> string -> (string list, [> `Msg of string ]) result
+  val with_switch_state_sel :  ?dir_name:Fpath.t -> (OpamTypes.switch_selections -> 'a) -> 'a
+
+  val with_virtual_state :
+    (OpamStateTypes.unlocked OpamStateTypes.switch_state -> 'a) -> 'a
+end
+
+module Conversions : sig
+  val version_of_pkg : OpamPackage.t -> string
 end
 
 val install : GlobalOpts.t -> string list -> (unit, [> `Msg of string ]) result

--- a/src/lib/sandbox_switch.mli
+++ b/src/lib/sandbox_switch.mli
@@ -2,20 +2,19 @@ open Import
 
 type t
 
+val get_sandbox_root : t -> Fpath.t
+
 val install :
   Opam.GlobalOpts.t ->
   t ->
   pkg:string * string option ->
   (unit, 'e) Result.or_msg
 
-val list_files :
-  Opam.GlobalOpts.t -> t -> pkg:string -> (Fpath.t list, 'e) Result.or_msg
-
 val switch_path_prefix : t -> Fpath.t
 
 val with_sandbox_switch :
   Opam.GlobalOpts.t ->
-  ocaml_version:Ocaml_version.t ->
+  ocaml:OpamPackage.t ->
   (t -> ('a, 'e) Result.or_msg) ->
   ('a, 'e) Result.or_msg
 (** Create a sandbox switch, call the passed function and finally remove the

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -1,7 +1,6 @@
 open! Import
 open Astring
 open Bos
-module OV = Ocaml_version
 open Result.Syntax
 
 type tool = { name : string; pure_binary : bool; version : string option }
@@ -9,117 +8,67 @@ type tool = { name : string; pure_binary : bool; version : string option }
    [OpamPackage.Name.t] for the type of [name] and something like ... for the
    type of [compiler_constr].*)
 
-let parse_constraints s =
-  let open Angstrom in
-  let is_whitespace = function
-    | '\x20' | '\x0a' | '\x0d' | '\x09' -> true
-    | _ -> false
-  in
-  let whitespace = take_while is_whitespace in
-  let whitespaced p = whitespace *> p <* whitespace in
-  let quoted p = whitespaced @@ (char '"' *> p) <* char '"' in
-  let bracketed p = whitespaced @@ (char '{' *> p) <* char '}' in
-  let quoted_ocaml = quoted @@ string "ocaml" in
-  let quoted_version =
-    quoted @@ take_till (( = ) '"') >>| fun version_string ->
-    OV.of_string_exn version_string
-  in
-  let comparator =
-    whitespaced @@ take_till is_whitespace >>= function
-    | "<" -> return `Lt
-    | "<=" -> return `Le
-    | ">" -> return `Gt
-    | ">=" -> return `Ge
-    | "=" -> return `Eq
-    | _ -> fail "not a comparator"
-  in
-  let constraint_ = both comparator quoted_version in
-  let constraints = sep_by (whitespaced @@ char '&') constraint_ in
-  let finally = quoted_ocaml *> bracketed constraints <* end_of_input in
-  match parse_string ~consume:Consume.All finally s with
-  | Ok a -> Ok a
-  | Error m -> Error (`Msg m)
-
-let verify_constraint version (op, constraint_version) =
-  let d = OV.compare version constraint_version in
-  match op with
-  | `Le -> d <= 0
-  | `Lt -> d < 0
-  | `Ge -> d >= 0
-  | `Gt -> d > 0
-  | `Eq -> d = 0
-
-let verify_constraints version constraints =
-  List.for_all (verify_constraint version) constraints
-
-let best_available_version opam_opts ocaml_version name =
-  let open Result.Syntax in
-  let+ versions = Opam.Show.available_versions opam_opts name in
-  let version =
-    versions
-    |> List.find (fun version ->
-           let ocaml_depends =
-             let+ depends =
-               Opam.Show.depends opam_opts (name ^ "." ^ version)
-             in
-             List.find_opt (String.is_prefix ~affix:"\"ocaml\"") depends
-           in
-           match ocaml_depends with
-           | Ok (Some ocaml_constraint) ->
-               let result =
-                 parse_constraints ocaml_constraint >>| fun constraints ->
-                 verify_constraints ocaml_version constraints
-               in
-               Result.value ~default:false result
-           | Ok None -> true
-           | _ -> false)
-  in
-  version
-
-let best_version_of_tool opam_opts ocaml_version tool =
+let best_version ~metadata_universe ~pkg_universe ~ocaml tool =
   (match tool.version with
   | Some ver -> Ok ver
-  | None -> best_available_version opam_opts ocaml_version tool.name)
+  | None -> (
+      match
+        Opam.Queries.latest_version ~metadata_universe ~pkg_universe:(Lazy.force pkg_universe) ~ocaml
+          tool.name
+      with
+      | Some ver -> Ok (Opam.Conversions.version_of_pkg ver)
+      | None ->
+          Result.errorf
+            "Something went wrong trying to find the best version for %s"
+            tool.name))
   >>| fun ver ->
-  Binary_package.binary_name ~ocaml_version ~name:tool.name ~ver
+  Binary_package.binary_name ~ocaml ~name:tool.name ~ver
     ~pure_binary:tool.pure_binary
 
-let make_binary_package opam_opts ~ocaml_version sandbox repo bname tool =
+let make_binary_package opam_opts ~ocaml sandbox repo bname tool =
   let { name; pure_binary; _ } = tool in
   Sandbox_switch.install opam_opts sandbox ~pkg:(tool.name, tool.version)
   >>= fun () ->
-  Binary_package.make_binary_package opam_opts ~ocaml_version sandbox repo bname
-    ~name ~pure_binary
+  Binary_package.make_binary_package opam_opts ~ocaml sandbox repo bname ~name
+    ~pure_binary
 
 let install opam_opts tools =
   let binary_repo_path =
     Fpath.(
       opam_opts.Opam.GlobalOpts.root / "plugins" / "ocaml-platform" / "cache")
   in
-  let* ovraw = Opam.Show.installed_version opam_opts "ocaml" in
-  (match ovraw with
-  | None -> Result.errorf "Cannot install tools: No switch is selected."
-  | Some s -> OV.of_string s)
-  >>= fun ocaml_version ->
+  let tools_names = List.map (fun tool -> tool.name) tools in
+  let installed =
+    Opam.Queries.(
+      with_switch_state_sel (installed_versions ("ocaml" :: tools_names)))
+  in
+  (match List.assoc_opt "ocaml" installed with
+  | Some (Some s) -> Ok s
+  | _ ->
+      Result.errorf "Cannot install tools: No switch with compiler is selected.")
+  >>= fun ocaml ->
   Binary_repo.init opam_opts binary_repo_path >>= fun repo ->
   (* [tools_to_build] is the list of tools that need to be built and placed in
      the cache. [tools_to_install] is the names of the packages to install into
      the user's switch, each string is a suitable argument to [opam install]. *)
   Logs.app (fun m -> m "Inferring tools version...");
   let* tools_to_build, tools_to_install =
-    let* version_list =
-      Opam.Show.installed_versions opam_opts
-        (List.map (fun tool -> tool.name) tools)
+    let pkg_universe, metadata_universe =
+      Opam.Queries.(
+        with_virtual_state (fun state ->
+            (get_pkg_universe state, get_metadata_universe state)))
     in
     Result.List.fold_left
       (fun (to_build, to_install) tool ->
-        let pkg_version = List.assoc_opt tool.name version_list in
+        let pkg_version = List.assoc_opt tool.name installed in
         match pkg_version with
         | Some (Some _) ->
             Logs.info (fun m -> m "%s is already installed" tool.name);
             Ok (to_build, to_install)
         | _ ->
-            let+ bname = best_version_of_tool opam_opts ocaml_version tool in
+            let+ bname =
+              best_version ~metadata_universe ~pkg_universe ~ocaml tool
+            in
             Logs.info (fun m ->
                 m "%s will be installed as %s" tool.name
                   (Binary_package.name_to_string bname));
@@ -134,13 +83,11 @@ let install opam_opts tools =
   | [] -> Ok ()
   | _ :: _ ->
       Logs.app (fun m -> m "Creating a sandbox to build the tools...");
-      Sandbox_switch.with_sandbox_switch opam_opts ~ocaml_version
-        (fun sandbox ->
+      Sandbox_switch.with_sandbox_switch opam_opts ~ocaml (fun sandbox ->
           Result.List.fold_left
             (fun () (tool, bname) ->
               Logs.app (fun m -> m "Building %s..." tool.name);
-              make_binary_package opam_opts ~ocaml_version sandbox repo bname
-                tool)
+              make_binary_package opam_opts ~ocaml sandbox repo bname tool)
             () tools_to_build))
   >>= fun () ->
   match tools_to_install with


### PR DESCRIPTION
Using the library instead of the binary has four advantages: it avoids parsing the printed output of the binary, it yields a cleaner code, it should speed up the time needed for the queries, and it makes us depend less on a binary whose future is uncertain. For the pen-ultimate statement about the speed-up, let's have a look at the CI and how long it takes for each step compared to before to see if that's actually true.

I'm already opening the PR to discuss if this is something we want to go forward with before doing the last things I'd do:
- have a look at what exactly [`env`](https://github.com/tarides/ocaml-platform-installer/compare/main...pitag-ha:use-opam-library?expand=1#diff-0377106cc8df6ef200609652c5bdf839f7b1dfb66fcbeb0b0ae2260031703d54R155) does when querying dependency state and possibly adapt it to what we need
- find out if the information stored in `Opam.GlobalObts` should still be used, also when making the queries via the library (it was used before and currently I'm not using it anymore)
- have a look if what I've done so far can be sped-up a bit more. I think the two places taking up time at the moment is loading the sandbox switch state to find the installed files by a tool and loading a virtual switch state to load a map with all opam packages to find out the version of the tools we want to install.
- take advantage of that now we're using the library to avoid passing around `string`s all the time and pass around more specific types instead (e.g. `OpamPackage.Name.t`).
- generally, clean up a bit

If I remember correctly, the last time you tried using the library, you discarded doing that for the following reasons:
- supposedly it's more complicated. I don't think I agree with that. I think the code stays similarly complex as it was before but becomes far cleaner now: see comments from before about not parsing the binary output anymore (which could be re-formatted at any time) and about using more specific types. Let me know if you still disagree though, please!
- different versions of the opam library in the binary installed by the user and the one we're using can lead to opam failures. To avoid that happening, I only load the switch state with read_only lock. For installing, we're still using the binary...
- it doesn't even speed-up things. I would be a bit surprised if that was true to be honest, but it's possible. Let's see what the time of the CI says.

Let me know what you think about this PR in general please to see if it's worth spending the time to improve the things mentioned above!