### PR TITLE
Fix the installer on macos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Better logs, including few sliding lines of opam output when necessary (#57)
 - Fix duplicate files in binary package archive (#71)
+- Fix the installer script not working on macos (#77)
 
 ## 0.1.0 (2022-06-15)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This installer installs all the tools of the Platform in a switch and aims at of
 To install the `ocaml-platform` binary, run the installer script as `root`:
 
 ```sh
-sudo bash < <(curl -L https://github.com/tarides/ocaml-platform-installer/releases/latest/download/installer.sh)
+sudo bash < <(curl -sL https://github.com/tarides/ocaml-platform-installer/releases/latest/download/installer.sh)
 ```
 
 Don't hesitate to have a look at what the script does.

--- a/src/distrib/make_installer.sh
+++ b/src/distrib/make_installer.sh
@@ -60,6 +60,15 @@ download()
     fi
 }
 
+# Args: sha512 path
+check_sha512()
+{
+  if command -v sha512sum >/dev/null
+  then sha512sum --check --quiet - <<<"\$1 \$2"
+  else shasum -a 512 --check --quiet - <<<"\$1 \$2"
+  fi
+}
+
 install_opam ()
 {
   local opam_bin opam_base_url sha512
@@ -84,7 +93,7 @@ install_opam ()
 
   echo "=> Download \$opam_bin"
   download opam "\$opam_base_url/\$opam_bin"
-  sha512sum --check --quiet - <<<"\$sha512 opam"
+  check_sha512 "\$sha512" opam
 
   echo "=> Install into \$PREFIX/bin"
   install -m755 "opam" "\$PREFIX/bin"
@@ -94,7 +103,7 @@ cd "\$(mktemp -d)"
 
 echo "=> Download \$archive" >&2
 download "\$archive" "$ARCHIVES_URL/\$archive"
-sha512sum --check --quiet - <<<"\$sha512 \$archive"
+check_sha512 "\$sha512" "\$archive"
 tar xf "\$archive"
 
 echo "=> Install into \$PREFIX/bin"


### PR DESCRIPTION
Fixes https://github.com/tarides/ocaml-platform-installer/issues/76

The first commit adds the `-s` flag to the curl invocation in the README. This removes the progress report, which was interfering with the sudo prompt.

The second commit uses `shasum` (which seems to be installed by default in many distros) to compute the sha512 of the downloaded archive if `sha512sum` (which isn't  available on macos) isn't installed.

I have not tested this on macos yet as I'm struggling to have a working VM.