### PR TITLE
Small fix for wrong behaviour when user interrupts sliding logs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Improve logging behaviour in case of user interrupt (#80)
 - Use an install file instead of install instruction in binary package (#73)
 - Better logs, including few sliding lines of opam output when necessary (#57)
 - Fix duplicate files in binary package archive (#71)

--- a/src/lib/ansi_box.ml
+++ b/src/lib/ansi_box.ml
@@ -82,10 +82,12 @@ let setup_box ~log_height f =
       let finally () =
         (* Restore previous sigwinch handler. *)
         Sys.set_signal sigwinch old_signal;
-        ANSITerminal.isatty := old_isatty;
-        clear_logs ()
+        ANSITerminal.isatty := old_isatty
       in
-      Fun.protect ~finally (fun () -> f log_line)
+      Fun.protect ~finally (fun () ->
+          let res = f log_line in
+          clear_logs ();
+          res)
 
 let read_and_print ~log_height ic ic_err (out_init, out_acc, out_finish) =
   let err_acc acc l = l :: acc in


### PR DESCRIPTION
When the user interrupts by calling Ctrl+c, while the program is writing sliding logs, the result is wrong: previous logs are replaced by the sliding logs, part of the sliding logs are half removed, the prompt is in the middle of half removed logs:  
![image](https://user-images.githubusercontent.com/34110029/177094531-6d6451a9-ee67-4097-a9c7-bcd1aa377bd3.png)

This PR fixes this by removing the `clear_logs` from the things that are executed at the end even in case of interruption:
![image](https://user-images.githubusercontent.com/34110029/177094623-4b7fccba-bf86-4b37-9c2f-80dfa4131bc6.png)

I am not completely sure why the former behavior happened consistently (it is like `clear_logs` was running twice), and how we could achieve what was wanted before (that the sliding logs are removed in case of user interruption), but I think it is good to keep the sliding logs in case of user interruption.