### PR TITLE
Allow for ocaml version that do not have an `ocaml-system` corresponding package (AKA OCaml 5 support!)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,6 +50,9 @@ jobs:
       - name: "Test: install"
         run: ./test/run_test.sh install
 
+      - name: "Test: ocaml5"
+        run: ./test/run_test.sh ocaml5
+
       - name: "Test: version"
         run: ./test/run_test.sh version
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- Add support for versions of ocaml where an `ocaml-system` package is not
+  provided in the default repo, such as for instance, OCaml 5! (#83)
 - Export the internal library `platform.binary_repo` (#82)
   The library manages the cache repository.
 - Fix the fact that man pages files were not included (#82)

--- a/src/lib/binary_repo/binary_package.ml
+++ b/src/lib/binary_repo/binary_package.ml
@@ -44,7 +44,7 @@ type full_name = Package.full_name
 (** Name and version of the binary package corresponding to a given package. *)
 let binary_name ~ocaml_version ~name ~ver ~pure_binary =
   let name = if pure_binary then name else name ^ "+bin+platform" in
-  let ver = ver ^ "-ocaml" ^ Ocaml_version.to_string ocaml_version in
+  let ver = ver ^ "-ocaml" ^ ocaml_version in
   Package.v ~name ~ver
 
 let name = Package.name
@@ -63,7 +63,7 @@ let generate_opam_file ~arch ~os_distribution original_name bname pure_binary
         Atom (`Eq, "os-distribution", os_distribution) )
   in
   let depends =
-    [ ("ocaml", [ (`Eq, Ocaml_version.to_string ocaml_version) ]) ]
+    [ ("ocaml", [ (`Eq, ocaml_version) ]) ]
   in
   Package.Opam_file.v ~depends ~available ?conflicts ~url:archive_path
     ~pkg_name:(name bname) ()

--- a/src/lib/binary_repo/binary_package.ml
+++ b/src/lib/binary_repo/binary_package.ml
@@ -63,7 +63,16 @@ let generate_opam_file ~arch ~os_distribution original_name bname pure_binary
         Atom (`Eq, "os-distribution", os_distribution) )
   in
   let depends =
-    [ ("ocaml", [ (`Eq, ocaml_version) ]) ]
+    let open Package.Opam_file in
+    [
+      Formula
+        ( `Or,
+          Formula
+            ( `Or,
+              Atom (`Eq, "ocaml-system", ocaml_version),
+              Atom (`Eq, "ocaml-variants", ocaml_version) ),
+          Atom (`Eq, "ocaml-base-compiler", ocaml_version) );
+    ]
   in
   Package.Opam_file.v ~depends ~available ?conflicts ~url:archive_path
     ~pkg_name:(name bname) ()

--- a/src/lib/binary_repo/binary_package.mli
+++ b/src/lib/binary_repo/binary_package.mli
@@ -6,7 +6,7 @@ open Bos
 type full_name
 
 val binary_name :
-  ocaml_version:Ocaml_version.t ->
+  ocaml_version:string ->
   name:string ->
   ver:string ->
   pure_binary:bool ->
@@ -20,7 +20,7 @@ val package : full_name -> Package.full_name
 type binary_pkg = Package.Install_file.t * Package.Opam_file.t
 
 val make_binary_package :
-  ocaml_version:Ocaml_version.t ->
+  ocaml_version:string ->
   arch:string ->
   os_distribution:string ->
   prefix:Fpath.t ->

--- a/src/lib/binary_repo/binary_repo.ml
+++ b/src/lib/binary_repo/binary_repo.ml
@@ -19,5 +19,5 @@ let has_binary_pkg repo pack =
 
 (** Binary is already in the sandbox. Add this binary as a package in the local
     repo *)
-let add_binary_package repo bpack (install, opam) =
-  Repo.add_package repo.repo (Binary_package.package bpack) install opam
+let add_binary_package repo bpack (install_file, opam) =
+  Repo.add_package repo.repo (Binary_package.package bpack) ~install_file opam

--- a/src/lib/binary_repo/dune
+++ b/src/lib/binary_repo/dune
@@ -2,4 +2,4 @@
  (name binary_repo)
  (public_name platform.binary_repo)
  (wrapped false)
- (libraries bos astring ocaml-version opam-file-format))
+ (libraries bos astring opam-file-format))

--- a/src/lib/binary_repo/package.ml
+++ b/src/lib/binary_repo/package.ml
@@ -8,7 +8,7 @@ let name { name; ver = _ } = name
 let ver { name = _; ver } = ver
 
 module Opam_file = struct
-  type t = OpamParserTypes.FullPos.opamfile
+  type t = string
   type cmd = string list
   type dep = string * ([ `Eq | `Geq | `Gt | `Leq | `Lt | `Neq ] * string) list
 
@@ -74,9 +74,11 @@ module Opam_file = struct
     let file_contents =
       [ opam_version; name ] @ install @ depends @ available @ conflicts @ url
     in
-    { OpamParserTypes.FullPos.file_contents; file_name }
+    OpamPrinter.FullPos.opamfile
+      { OpamParserTypes.FullPos.file_contents; file_name }
 
-  let to_string t = OpamPrinter.FullPos.opamfile t
+  let to_string t = t
+  let of_string t = t
 end
 
 module Install_file = struct

--- a/src/lib/binary_repo/package.mli
+++ b/src/lib/binary_repo/package.mli
@@ -32,6 +32,7 @@ module Opam_file : sig
     t
 
   val to_string : t -> string
+  val of_string : string -> t
 end
 
 module Install_file : sig

--- a/src/lib/binary_repo/package.mli
+++ b/src/lib/binary_repo/package.mli
@@ -13,9 +13,6 @@ module Opam_file : sig
   type t
   type cmd = string list
 
-  type dep = string * ([ `Eq | `Geq | `Gt | `Leq | `Lt | `Neq ] * string) list
-  (** [name * (operator * constraint) option]. *)
-
   type atom = [ `Eq | `Geq | `Gt | `Leq | `Lt | `Neq ] * string * string
   (** [operator * var_name * constraint] *)
 
@@ -23,7 +20,7 @@ module Opam_file : sig
 
   val v :
     ?install:cmd list ->
-    ?depends:dep list ->
+    ?depends:formula list ->
     ?conflicts:string list ->
     ?available:formula ->
     ?url:Fpath.t ->

--- a/src/lib/binary_repo/repo.mli
+++ b/src/lib/binary_repo/repo.mli
@@ -19,7 +19,7 @@ val add_package :
   t ->
   Package.full_name ->
   ?extra_files:(string * string) list ->
-  Package.Install_file.t ->
+  ?install_file:Package.Install_file.t ->
   Package.Opam_file.t ->
   (unit, 'e) OS.result
 (** [add_package opam_opts repo pkg ~extra_files install_file opam_file] adds a

--- a/src/lib/binary_repo/repo.mli
+++ b/src/lib/binary_repo/repo.mli
@@ -18,6 +18,10 @@ val has_pkg : t -> Package.full_name -> bool
 val add_package :
   t ->
   Package.full_name ->
+  ?extra_files:(string * string) list ->
   Package.Install_file.t ->
   Package.Opam_file.t ->
   (unit, 'e) OS.result
+(** [add_package opam_opts repo pkg ~extra_files install_file opam_file] adds a
+    package to the repo. [extra_files] is a list of [ filename * content] to be
+    put under [files/] folder *)

--- a/src/lib/installed_repo.ml
+++ b/src/lib/installed_repo.ml
@@ -5,5 +5,5 @@ let update opam_opts t = Opam.update opam_opts [ Repo.name t ]
 let with_repo_enabled opam_opts t f =
   let repo_name = Repo.name t and repo_path = Repo.path t in
   let unselect_repo () = ignore @@ Opam.Repository.remove opam_opts repo_name in
-  Opam.Repository.add opam_opts ~url:(Fpath.to_string repo_path) repo_name
-  >>= fun () -> Fun.protect ~finally:unselect_repo f
+  Opam.Repository.add opam_opts ~path:repo_path repo_name >>= fun () ->
+  Fun.protect ~finally:unselect_repo f

--- a/src/lib/opam.ml
+++ b/src/lib/opam.ml
@@ -199,6 +199,9 @@ module Show = struct
     let+ res = parse res in
     List.map (function a, "--" -> (a, None) | a, s -> (a, Some s)) res
 
+  let opam_file opam_opts ~pkg =
+    Cmd.run_s opam_opts Bos.Cmd.(v "show" % pkg % "-f" % "opam-file")
+
   let depends opam_opts pkg_name =
     Cmd.run_l opam_opts Bos.Cmd.(v "show" % "-f" % "depends:" % pkg_name)
 

--- a/src/lib/opam.ml
+++ b/src/lib/opam.ml
@@ -139,10 +139,11 @@ module Switch = struct
 end
 
 module Repository = struct
-  let add opam_opts ~url name =
+  let add opam_opts ~path name =
     Cmd.run opam_opts
       Bos.Cmd.(
-        v "repository" % "add" % "--this-switch" % "-k" % "local" % name % url)
+        v "repository" % "add" % "--this-switch" % "-k" % "local" % name
+        % p path)
 
   let remove opam_opts name =
     Cmd.run opam_opts

--- a/src/lib/opam.mli
+++ b/src/lib/opam.mli
@@ -77,6 +77,8 @@ module Show : sig
     string list ->
     ((string * string option) list, 'a) Result.or_msg
 
+  val opam_file : GlobalOpts.t -> pkg:string -> (string, 'a) Result.or_msg
+
   val depends :
     GlobalOpts.t -> string -> (string list, [> `Msg of string ]) result
 

--- a/src/lib/opam.mli
+++ b/src/lib/opam.mli
@@ -57,7 +57,7 @@ end
 
 module Repository : sig
   val add :
-    GlobalOpts.t -> url:string -> string -> (unit, [> `Msg of string ]) result
+    GlobalOpts.t -> path:Fpath.t -> string -> (unit, [> `Msg of string ]) result
 
   val remove : GlobalOpts.t -> string -> (unit, [> `Msg of string ]) result
 end

--- a/src/lib/sandbox_compiler_package.ml
+++ b/src/lib/sandbox_compiler_package.ml
@@ -70,21 +70,80 @@ let extra_file =
   close_out oc
 |}
 
-let init opam_opts ocaml_version =
-  let name = "platform_sandbox_compiler_packages" in
-  let path =
-    Fpath.(opam_opts.Opam.GlobalOpts.root / "plugins" / "ocaml-platform" / name)
+(** The [~alpha...] suffix needs to be removed when overriding the [ocaml]
+    package. *)
+let remove_alpha_suffix ver =
+  match String.cut ~sep:"~" ver with Some (pre, _) -> pre | None -> ver
+
+(** Lookup in the selected switch. *)
+let lookup_ocaml_descr opam_opts = Opam.Show.opam_file opam_opts ~pkg:"ocaml"
+
+(** Fix [ocaml]'s constraint on [ocaml-system], which disallow alpha versions. *)
+let fix_ocaml_constraints opam_file ~ocaml_version =
+  let open OpamParserTypes.FullPos in
+  let with_pos f wp = { wp with pelem = f wp.pelem } in
+  let fake_pos pelem =
+    { pelem; pos = { filename = ""; start = (0, 0); stop = (0, 0) } }
   in
-  let pkg =
-    Package.v ~name:"ocaml-system" ~ver:ocaml_version
+  let name_is_ocaml t =
+    match t.pelem with String "ocaml-system" -> true | _ -> false
   in
-  let* repo = Repo.init ~name path in
-  if Repo.has_pkg repo pkg then Ok repo
+  let rec fix_depend = function
+    | Option (name, _args) when name_is_ocaml name ->
+        let cnstr =
+          Prefix_relop (fake_pos `Eq, fake_pos (String ocaml_version))
+        in
+        Option (name, fake_pos [ fake_pos cnstr ])
+    | Logop (op, left, right) ->
+        Logop (op, with_pos fix_depend left, with_pos fix_depend right)
+    | t -> t
+  in
+  let fix_depends = function
+    | List elems -> List (with_pos (List.map (with_pos fix_depend)) elems)
+    | t -> t
+  in
+  let fix_item = function
+    | Variable (({ pelem = "depends"; _ } as name), value) ->
+        Variable (name, with_pos fix_depends value)
+    | t -> t
+  in
+  let fix_opamfile t =
+    { t with file_contents = List.map (with_pos fix_item) t.file_contents }
+  in
+  OpamParser.FullPos.string opam_file "ocaml"
+  |> fix_opamfile |> OpamPrinter.FullPos.opamfile
+
+(** Override the [ocaml-system] package to drop the [sys-ocaml-version]
+    constraint and to specify the right version for it, for example
+    [ocaml-system.5.0.0~alpha0] doesn't exist. *)
+let init_pkg_ocaml_system repo ~ocaml_version =
+  let pkg = Package.v ~name:"ocaml-system" ~ver:ocaml_version in
+  if Repo.has_pkg repo pkg then Ok ()
   else
     let opam_file = Package.Opam_file.of_string @@ opam_file () in
     let install_file =
       Package.Install_file.v String.Map.empty ~pkg_name:(Package.name pkg)
     in
     let extra_files = [ ("gen_ocaml_config.ml.in", extra_file) ] in
-    let* () = Repo.add_package repo pkg ~extra_files install_file opam_file in
-    Ok repo
+    Repo.add_package repo pkg ~extra_files ~install_file opam_file
+
+(** Override the [ocaml] package to fix the dependency it has on [ocaml-system],
+    which disallow [~] suffixes. The [ocaml] package itself must not use a [~]
+    suffix. *)
+let init_pkg_ocaml opam_opts repo ~ocaml_version =
+  let pkg = Package.v ~name:"ocaml" ~ver:(remove_alpha_suffix ocaml_version) in
+  if Repo.has_pkg repo pkg then Ok ()
+  else
+    let* opam_file = lookup_ocaml_descr opam_opts in
+    let opam_file = fix_ocaml_constraints opam_file ~ocaml_version in
+    Repo.add_package repo pkg (Package.Opam_file.of_string opam_file)
+
+let init opam_opts ocaml_version =
+  let name = "platform_sandbox_compiler_packages" in
+  let path =
+    Fpath.(opam_opts.Opam.GlobalOpts.root / "plugins" / "ocaml-platform" / name)
+  in
+  let* repo = Repo.init ~name path in
+  let* () = init_pkg_ocaml_system repo ~ocaml_version in
+  let* () = init_pkg_ocaml opam_opts repo ~ocaml_version in
+  Ok repo

--- a/src/lib/sandbox_compiler_package.ml
+++ b/src/lib/sandbox_compiler_package.ml
@@ -1,0 +1,90 @@
+open Import
+open Result.Syntax
+open Astring
+
+let opam_file () =
+  {|opam-version: "2.0"
+synopsis: "The OCaml compiler (system version, from outside of opam)"
+maintainer: "platform@lists.ocaml.org"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {post}
+  "base-unix" {post}
+  "base-threads" {post}
+  "base-bigarray" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+build: ["ocaml" "gen_ocaml_config.ml"]
+substs: "gen_ocaml_config.ml"
+extra-files: ["gen_ocaml_config.ml.in" "md5=093e7bec1ec95f9e4c6a313d73c5d840"]
+|}
+
+let extra_file =
+  {|let () =
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
+  if Sys.ocaml_version <> "%{_:version}%" then
+    (Printf.eprintf
+       "ERROR: The compiler found at %%s has version %%s,\n\
+        and this package requires %{_:version}%.\n\
+        You should use e.g. 'opam switch create %{_:name}%.%%s' \
+        instead."
+       ocamlc Sys.ocaml_version Sys.ocaml_version;
+     exit 1)
+  else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
+  let oc = open_out "%{_:name}%.config" in
+  Printf.fprintf oc "opam-version: \"2.0\"\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
+                     variables { path: %%S }\n"
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
+  close_out oc
+|}
+
+let init opam_opts ocaml_version =
+  let name = "platform_sandbox_compiler_packages" in
+  let path =
+    Fpath.(opam_opts.Opam.GlobalOpts.root / "plugins" / "ocaml-platform" / name)
+  in
+  let pkg =
+    Package.v ~name:"ocaml-system" ~ver:(Ocaml_version.to_string ocaml_version)
+  in
+  let* repo = Repo.init ~name path in
+  if Repo.has_pkg repo pkg then Ok repo
+  else
+    let opam_file = Package.Opam_file.of_string @@ opam_file () in
+    let install_file =
+      Package.Install_file.v String.Map.empty ~pkg_name:(Package.name pkg)
+    in
+    let extra_files = [ ("gen_ocaml_config.ml.in", extra_file) ] in
+    let* () = Repo.add_package repo pkg ~extra_files install_file opam_file in
+    Ok repo

--- a/src/lib/sandbox_compiler_package.ml
+++ b/src/lib/sandbox_compiler_package.ml
@@ -76,7 +76,7 @@ let init opam_opts ocaml_version =
     Fpath.(opam_opts.Opam.GlobalOpts.root / "plugins" / "ocaml-platform" / name)
   in
   let pkg =
-    Package.v ~name:"ocaml-system" ~ver:(Ocaml_version.to_string ocaml_version)
+    Package.v ~name:"ocaml-system" ~ver:ocaml_version
   in
   let* repo = Repo.init ~name path in
   if Repo.has_pkg repo pkg then Ok repo

--- a/src/lib/sandbox_compiler_package.mli
+++ b/src/lib/sandbox_compiler_package.mli
@@ -1,0 +1,5 @@
+open Import
+
+val init : Opam.GlobalOpts.t -> Ocaml_version.t -> (Repo.t, 'e) Result.or_msg
+(** [init opam_opts ocaml_version] creates (if needed) a repo containing a
+    patched version of [ocaml-system] working well with the sandbox switch. *)

--- a/src/lib/sandbox_compiler_package.mli
+++ b/src/lib/sandbox_compiler_package.mli
@@ -1,5 +1,5 @@
 open Import
 
-val init : Opam.GlobalOpts.t -> Ocaml_version.t -> (Repo.t, 'e) Result.or_msg
+val init : Opam.GlobalOpts.t -> string -> (Repo.t, 'e) Result.or_msg
 (** [init opam_opts ocaml_version] creates (if needed) a repo containing a
     patched version of [ocaml-system] working well with the sandbox switch. *)

--- a/src/lib/sandbox_switch.mli
+++ b/src/lib/sandbox_switch.mli
@@ -15,7 +15,7 @@ val switch_path_prefix : t -> Fpath.t
 
 val with_sandbox_switch :
   Opam.GlobalOpts.t ->
-  ocaml_version:Ocaml_version.t ->
+  ocaml_version:string ->
   (t -> ('a, 'e) Result.or_msg) ->
   ('a, 'e) Result.or_msg
 (** Create a sandbox switch, call the passed function and finally remove the

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -101,17 +101,18 @@ let make_binary_package opam_opts ~ocaml_version sandbox repo bname tool =
   in
   Binary_repo.add_binary_package repo bname bpkg
 
+(** This version is used to select the highest available version of the tools
+    and also to override the [ocaml-system] package declaration in the sandbox. *)
+let installed_ocaml_version opam_opts =
+  Opam.Config.Var.get opam_opts "ocaml:compiler"
+
 let install opam_opts tools =
   let binary_repo_path =
     Fpath.(
       opam_opts.Opam.GlobalOpts.root / "plugins" / "ocaml-platform" / "cache")
   in
-  let* ovraw = Opam.Show.installed_version opam_opts "ocaml" in
-  (match ovraw with
-  | None -> Result.errorf "Cannot install tools: No switch is selected."
-  | Some s -> Ok s)
-  >>= fun ocaml_version ->
-  Binary_repo.init binary_repo_path >>= fun repo ->
+  let* ocaml_version = installed_ocaml_version opam_opts in
+  let* repo = Binary_repo.init binary_repo_path in
   (* [tools_to_build] is the list of tools that need to be built and placed in
      the cache. [tools_to_install] is the names of the packages to install into
      the user's switch, each string is a suitable argument to [opam install]. *)

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -54,6 +54,7 @@ let verify_constraints version constraints =
 
 let best_available_version opam_opts ocaml_version name =
   let open Result.Syntax in
+  let* ocaml_version = OV.of_string ocaml_version in
   let+ versions = Opam.Show.available_versions opam_opts name in
   let version =
     versions
@@ -108,7 +109,7 @@ let install opam_opts tools =
   let* ovraw = Opam.Show.installed_version opam_opts "ocaml" in
   (match ovraw with
   | None -> Result.errorf "Cannot install tools: No switch is selected."
-  | Some s -> OV.of_string s)
+  | Some s -> Ok s)
   >>= fun ocaml_version ->
   Binary_repo.init binary_repo_path >>= fun repo ->
   (* [tools_to_build] is the list of tools that need to be built and placed in

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -104,7 +104,10 @@ let make_binary_package opam_opts ~ocaml_version sandbox repo bname tool =
 (** This version is used to select the highest available version of the tools
     and also to override the [ocaml-system] package declaration in the sandbox. *)
 let installed_ocaml_version opam_opts =
-  Opam.Config.Var.get opam_opts "ocaml:compiler"
+  let* ocaml_comp_ver = Opam.Config.Var.get opam_opts "ocaml:compiler" in
+  match ocaml_comp_ver with
+  | "system" -> Opam.Config.Var.get opam_opts "ocaml-system:version"
+  | o -> Ok o
 
 let install opam_opts tools =
   let binary_repo_path =

--- a/test/dockerfiles/Dockerfile.ocaml5
+++ b/test/dockerfiles/Dockerfile.ocaml5
@@ -1,0 +1,19 @@
+ARG TARGETPLATFORM=$TARGETPLATFORM
+
+FROM ocaml-platform-build-$TARGETPLATFORM:latest as base
+
+FROM ocaml-platform-install-$TARGETPLATFORM:latest
+
+COPY --from=base /usr/local/bin/ocaml-platform /usr/local/bin/ocaml-platform
+
+RUN true
+    # https://stackoverflow.com/questions/51115856/docker-failed-to-export-image-failed-to-create-image-failed-to-get-layer
+
+COPY test/tests/switch-5.0.sh .
+
+RUN bash switch-5.0.sh
+
+COPY test/tests/ocaml5.sh .
+
+RUN bash ocaml5.sh
+

--- a/test/tests/ocaml5.sh
+++ b/test/tests/ocaml5.sh
@@ -1,0 +1,13 @@
+#/usr/bin/env bash
+set -euo pipefail
+
+eval $(opam env)
+
+ocaml-platform -vv
+
+[[ $(which ocamlformat) = "/home/user/.opam/5.0.0~alpha1/bin/ocamlformat" ]];
+[[ $(which dune) = "/home/user/.opam/5.0.0~alpha1/bin/dune" ]];
+[[ $(which ocamlmerlin) = "/home/user/.opam/5.0.0~alpha1/bin/ocamlmerlin" ]];
+[[ $(which dune-release) = "/home/user/.opam/5.0.0~alpha1/bin/dune-release" ]];
+[[ $(which odoc) = "/home/user/.opam/5.0.0~alpha1/bin/odoc" ]];
+[[ $(which ocamllsp) = "/home/user/.opam/5.0.0~alpha1/bin/ocamllsp" ]];

--- a/test/tests/switch-5.0.sh
+++ b/test/tests/switch-5.0.sh
@@ -1,0 +1,8 @@
+#/usr/bin/env bash
+set -euo pipefail
+
+opam update
+
+opam switch create 5.0.0~alpha1 --repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
+
+


### PR DESCRIPTION
In this PR, we fix the issue that only compiler version that have a corresponding `ocaml-system` could be installed.

We fix this by creating (yet another) local repo with custom `ocaml-system` and `ocaml` packages, that the sandbox switch will use to "install" its compiler.

This makes the installer support OCaml 5 :smile: as well as other variants.

Pairprogrammed with @Julow and based on #82.