### PR TITLE
Fixing errors logging, Adding dependencies and link to Up and Running to the README

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- Fix error line appearing in reverse order, and show error in exection even in
+  `-v` verbose mode (#84).
 - Add an `available` field with `arch` and `os-distribution` in the opam files
   of the binary package (#74)
 - Improve logging behaviour in case of user interrupt (#80)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@ This installer installs all the tools of the Platform in a switch and aims at of
 
 ## Trying the Platform
 
-To install the `ocaml-platform` binary, run the installer script as `root`:
+To install the `ocaml-platform` binary, you'll need the following dependencies: `bzip2`, `make`, `gcc`, `bubblewrap`, `patch`, `curl` and `unzip`. In most architecture, you can install them using your package manager, for instance:
+
+``` sh
+sudo apt install bzip2 make gcc bubblewrap rsync patch curl unzip
+```
+
+You can now run the installer script as `root`:
 
 ```sh
 sudo bash < <(curl -sL https://github.com/tarides/ocaml-platform-installer/releases/latest/download/installer.sh)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This installer installs all the tools of the Platform in a switch and aims at of
 
 ## Trying the Platform
 
-To install the `ocaml-platform` binary, you'll need the following dependencies: `bzip2`, `make`, `gcc`, `bubblewrap`, `patch`, `curl` and `unzip`. In most architecture, you can install them using your package manager, for instance:
+The official guide [Up and Running with OCaml](https://ocaml.org/docs/up-and-running) explains how to set up a complete work environment for your OCaml projects. It is a necessary reading for every OCaml newcomer.
+
+This set-up goes through several steps, some of which have to be redone for every new project. The `ocaml-platform` binary, automates and speeds those steps. However, you still need first to install the few dependencies of the OCaml environment, such as a C compiler (such as `gcc`) and other system tools: `bzip2`, `make`, `bubblewrap`, `patch`, `curl` and `unzip`. In most architecture, you can install them using your package manager, for example on Ubuntu or Debian:
 
 ``` sh
 sudo apt install bzip2 make gcc bubblewrap rsync patch curl unzip
@@ -25,7 +27,7 @@ Don't hesitate to have a look at what the script does.
 In a nutshell, the script will install a static binary into `/usr/local/bin/ocaml-platform` as well as the `opam` binary if it isn't already installed.
 Currently, only Linux (both amd64 and arm64) and macOS (only amd64) are supported. macOS arm64 requires Rosetta to be installed. We plan on adding more targets soon.
 
-Then, to install the Platform tools inside your opam switch:
+Then, to install the Platform tools inside your opam switch (if you don't know what is a switch, read the [Up and running with OCaml guide](https://ocaml.org/docs/up-and-running)):
 
 ```
 ocaml-platform

--- a/src/lib/ansi_box.ml
+++ b/src/lib/ansi_box.ml
@@ -116,4 +116,4 @@ let read_and_print ~log_height ic ic_err (out_init, out_acc, out_finish) =
   Lwt_main.run
     (let+ acc = process_stdout ~log_line out_init
      and+ acc_err = process_stderr ~log_line [] in
-     (out_finish acc, acc_err))
+     (out_finish acc, List.rev acc_err))

--- a/src/lib/opam.ml
+++ b/src/lib/opam.ml
@@ -54,7 +54,7 @@ module Cmd = struct
     let s_err = String.concat ~sep:"\n" res_err in
     (match s_err with
     | "" -> ()
-    | s -> Logs.debug (fun m -> m "Error in execution: %s" s));
+    | s -> Logs.info (fun m -> m "Error in %s:\n%s" cmd_s s));
     let result, status, success =
       (res, Unix.close_process_full channels) |> out_wrap
     in


### PR DESCRIPTION
The error message in case of missing dependency in ocaml-platform is not explicit at all:
For instance, if `patch` and `unzip` are missing, here would be the outputs:

In non verbose and verbose:
```
root@9acca02b34cb:/# ocaml-platform 
ocaml-platform: [ERROR] Command 'opam init --yes -q --color=never --root /root/.opam' failed: exited with 50
root@9acca02b34cb:/# ocaml-platform -v
ocaml-platform: [ERROR] Command 'opam init --yes -q --color=never --root /root/.opam' failed: exited with 50
```
and in very verbose mode
```
root@6906f5bf3e4a:/# ocaml-platform -vv
ocaml-platform: [DEBUG] Running: 'opam' 'init' '--yes' '-q' '--color=never' '--root' '/root/.opam'
ocaml-platform: [DEBUG] Error in execution:   - unzip
  - patch
[ERROR] Missing dependencies -- the following commands are required for opam to operate:
[WARNING] Running as root is not recommended
ocaml-platform: [ERROR] Command 'opam init --yes -q --color=never --root /root/.opam' failed: exited with 50
```

This PR does 3 things:
- Make it clear what are the dependencies in the README. The dependencies are related to an empty ubuntu docker image, there might be more...
- Output the error lines using the right order:
```
[WARNING] Running as root is not recommended
[ERROR] Missing dependencies -- the following commands are required for opam to operate:
  - patch
  - unzip
```
instead of 
```
  - unzip
  - patch
[ERROR] Missing dependencies -- the following commands are required for opam to operate:
[WARNING] Running as root is not recommended
```
- Output the errors obtained including in the normally verbose mode `-v`.

What do you think? I am not sure the inclusion in the README is important, but I think the two other points are improvements.