### PR TITLE
Remove mention of `utop` in the `--help` page

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -69,8 +69,6 @@ let main () =
         `Noblank;
         `P "- LSP server: $(b,ocaml-lsp)";
         `Noblank;
-        `P "- REPL: $(b,utop)";
-        `Noblank;
         `P "- Editor helper: $(b,merlin)";
         `P
           "You can install the OCaml Platform tools in your current $(b,opam) \


### PR DESCRIPTION
The installation of `utop` is not managed by `ocaml-platform`. It should not be mentioned in the `--help` page!