### PR TITLE
Continue installing if a tool is not available

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+- Continue installing if a tool is not available (#90)
+  Instead of stopping for complaining.
+
 ## 0.3.0 (2022-09-05)
 
 - Add support for versions of ocaml where an `ocaml-system` package is not

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -188,8 +188,8 @@ let install opam_opts tools =
       in
       Logs.app (fun m ->
           m
-            "  -> All tools installed. For more information on the platform \
-             tools, run `ocaml-platform --help`");
+            "  -> The tools have been installed. For more information on the \
+             platform tools, run `ocaml-platform --help`");
       Logs.app (fun m -> m "* Success."))
   >>= fun () ->
   if tools_not_installed <> [] then


### PR DESCRIPTION
Currently, if a tool is not compatible with the selected compiler, an
uncaught exception happens and the process is killed.

To avoid this, incompatible tools are logged and the installer is
allowed to continue with the other tools in the list.
Missing tools are also printed again at the end for clarity.

For example, `ocaml-lsp-server` is not compatible with `ocaml.5.0.0~alpha0`:

```
* Inferring tools version...
  -> dune will be installed as dune.3.3.1-ocaml5.0.0~alpha0
  -> dune-release will be installed as dune-release+bin+platform.1.6.2-ocaml5.0.0~alpha0
  -> merlin will be installed as merlin+bin+platform.4.4.1~5.0preview-ocaml5.0.0~alpha0
ocaml-platform: internal error, uncaught exception:
                Not_found
```

The output now looks like this:

```
* Inferring tools version...
  -> dune will be installed as dune.3.3.1-ocaml5.0.0~alpha0
  -> dune-release will be installed as dune-release+bin+platform.1.6.2-ocaml5.0.0~alpha0
  -> merlin will be installed as merlin+bin+platform.4.4.1~5.0preview-ocaml5.0.0~alpha0
ocaml-platform: [WARNING] ocaml-lsp-server cannot be installed with OCaml 5.0.0~alpha0
  -> odoc will be installed as odoc+bin+platform.2.1.0-ocaml5.0.0~alpha0
  -> ocamlformat will be installed as ocamlformat+bin+platform.0.22.4-ocaml5.0.0~alpha0
* Building the tools...
  -> Creating a sandbox...
  -> [1/5] Building ocamlformat...
  -> [2/5] Building odoc...
  -> [3/5] Building merlin...
  -> [4/5] Building dune-release...
  -> [5/5] Building dune...
* Installing tools...
  -> All tools installed. For more information on the platform tools, run `ocaml-platform --help`
* Success.
ocaml-platform: [WARNING] The following tools haven't been installed: ocaml-lsp-server
```
