### PR TITLE
Use the `OPAMCLI` env var to fix the CLI version to "2.0"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- Use OPAMCLI environment variable set to "2.0" to force the CLI version of
+  future opam version. (#92)
 - Continue installing if a tool is not available (#90)
   Instead of stopping for complaining.
 

--- a/src/lib/opam.ml
+++ b/src/lib/opam.ml
@@ -45,7 +45,9 @@ module Cmd = struct
         | None -> OS.Env.current ()
         | Some env -> Ok env
       in
-      env |> String.Map.to_seq
+      env
+      |> String.Map.add "OPAMCLI" "2.0"
+      |> String.Map.to_seq
       |> Seq.map (fun (a, b) -> a ^ "=" ^ b)
       |> Array.of_seq
     in


### PR DESCRIPTION
The `opam` cli is versioned. We want to support opam 2.0 and therefore have to define an `OPAMCLI` environment variable, ignored by opam 2.0, and making opam>2.0 use the opam 2.0 cli.

This environment variable is added to `opam_opts`'s environment as it is only the `Opam` module which can decide which version to use.

Previous
```
ser@d6ed97d05644:~$ ocaml-platform -vv
ocaml-platform: [DEBUG] Running: 'opam' 'config' 'var' 'ocaml:compiler' '--yes' '-q' '--color=never' '--root' '/home/user/.opam'
ocaml-platform: [INFO] Error in 'opam' 'config' 'var' 'ocaml:compiler' '--yes' '-q' '--color=never' '--root' '/home/user/.opam':
[WARNING] var was deprecated in version 2.1 of the opam CLI. Use opam var instead or set OPAMCLI environment variable to 2.0.
ocaml-platform: [DEBUG] Running: 'opam' 'config' 'var' 'ocaml-system:version' '--yes' '-q' '--color=never' '--root' '/home/user/.opam'
ocaml-platform: [INFO] Error in 'opam' 'config' 'var' 'ocaml-system:version' '--yes' '-q' '--color=never' '--root' '/home/user/.opam':
[WARNING] var was deprecated in version 2.1 of the opam CLI. Use opam var instead or set OPAMCLI environment variable to 2.0.
```
are no longer here!