### PR TITLE
Log before initialising Opam

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Log before initialising Opam (#93)
 - Use OPAMCLI environment variable set to "2.0" to force the CLI version of
   future opam version. (#92)
 - Continue installing if a tool is not available (#90)

--- a/src/lib/opam.ml
+++ b/src/lib/opam.ml
@@ -232,6 +232,10 @@ let check_init () =
   let open Result.Syntax in
   let* exists = Bos.OS.Dir.exists root in
   if exists then Ok ()
-  else
+  else (
+    Logs.app (fun m ->
+        m
+          "* Initialising Opam before the first use, this might take some \
+           time...");
     let cmd = Bos.Cmd.(v "init") in
-    Cmd.run GlobalOpts.default cmd
+    Cmd.run GlobalOpts.default cmd)

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -144,9 +144,10 @@ let install opam_opts tools =
                   if Binary_repo.has_binary_pkg repo bname then to_build
                   else (tool, bname) :: to_build
                 in
-                Ok ( to_build,
-                  Binary_package.to_string bname :: to_install,
-                  not_installed )
+                Ok
+                  ( to_build,
+                    Binary_package.to_string bname :: to_install,
+                    not_installed )
             | Error `Not_found ->
                 Logs.warn (fun m ->
                     m "%s cannot be installed with OCaml %s" tool.name


### PR DESCRIPTION
It's a good practice to avoid blocking for several minutes without any logging.