### PR TITLE
Constraint OCaml >= 4.10.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -29,6 +29,8 @@
  (description
   "The OCaml Platform represents the best way for developers, both new and old, to write software in OCaml. It combines a coherent set of tools, documentation and resources to be productive with OCaml.")
  (depends
+  (ocaml
+   (>= 4.10.0))
   ocaml-version
   angstrom
   (cmdliner

--- a/platform.opam
+++ b/platform.opam
@@ -22,6 +22,7 @@ homepage: "https://github.com/tarides/ocaml-platform"
 bug-reports: "https://github.com/tarides/ocaml-platform/issues"
 depends: [
   "dune" {>= "3.0"}
+  "ocaml" {>= "4.10.0"}
   "ocaml-version"
   "angstrom"
   "cmdliner" {>= "1.1.0"}


### PR DESCRIPTION
The CI reported build failures with OCaml 4.10.0 but instead of fixing them, I suggest supporting only the more recent versions.

This project is not meant to be built inside an Opam switch, which means that we can have more freedom in our dependencies without thinking about compatibility with other tools.