### PR TITLE
Fix usage of `shasum` command

### DIFF
--- a/src/distrib/make_installer.sh
+++ b/src/distrib/make_installer.sh
@@ -65,7 +65,7 @@ check_sha512()
 {
   if command -v sha512sum >/dev/null
   then sha512sum --check --quiet - <<<"\$1 \$2"
-  else shasum -a 512 --check --quiet - <<<"\$1 \$2"
+  else shasum -a 512 --check --quiet - <<<"\$1  \$2"
   fi
 }
 


### PR DESCRIPTION
The arguments of the command need to be separated by two spaces.

See https://issuecloser.com/blog/add-extra-space-between-shasum-args for an explanation:

> When checking, the input should be a former output of this program. The default mode is to print a line with checksum, a character indicating type (*' for binary, ' for text, U' for UNIVERSAL,^' for BITS, `?' for portable), and name for each FILE.
> 
> So the first space denotes the text type, and the second space separates the sum+type from the filename.

cc @samoht, thanks for the report!