### PR TITLE
Install opam 2.1.3 in the installer script

### DIFF
--- a/src/distrib/make_installer.sh
+++ b/src/distrib/make_installer.sh
@@ -96,7 +96,7 @@ install_opam ()
   check_sha512 "\$sha512" opam
 
   echo "=> Install into \$PREFIX/bin"
-  sudo install -m755 "opam" "\$PREFIX/bin"
+  install -m755 "opam" "\$PREFIX/bin"
 }
 
 cd "\$(mktemp -d)"
@@ -107,7 +107,7 @@ check_sha512 "\$sha512" "\$archive"
 tar xf "\$archive"
 
 echo "=> Install into \$PREFIX/bin"
-sudo install -m755 bin/* "\$PREFIX/bin"
+install -m755 bin/* "\$PREFIX/bin"
 
 # Install Opam if necessary
 if ! [[ -e \$PREFIX/bin/opam ]]; then

--- a/src/distrib/make_installer.sh
+++ b/src/distrib/make_installer.sh
@@ -72,17 +72,17 @@ check_sha512()
 install_opam ()
 {
   local opam_bin opam_base_url sha512
-  opam_bin=opam-2.1.2-\$targetarch-\$targetos
-  opam_base_url=https://github.com/ocaml/opam/releases/download/2.1.2
+  opam_bin=opam-2.1.3-\$targetarch-\$targetos
+  opam_base_url=https://github.com/ocaml/opam/releases/download/2.1.3
   case \$opam_bin in
-    opam-2.1.2-arm64-linux)     sha512=439b4d67c2888058df81b265148a3468b753c14700a8be38d091b76bf2777b5da5e9c8752839a92878cd377dd4bfbd5c3a458e7a26bff73e35056b60591d30f0 ;;
-    opam-2.1.2-arm64-macos)     sha512=55879f3e18bbc70c32d06f21f4ef785d54ef052920f57f1847c2cddc15af2f08e82d32022e7284fa43b07d56e4ba2f5155956b3673c3def8cd2f5c2cb8f68e48 ;;
-    opam-2.1.2-armhf-linux)     sha512=b9ee73e04ebaab23348e990b6e1d678fa0a66f5c0124e397761c6b9b2f1a8cb6fb2fa97da119aed520097f47ac7f8a2095f310891c72b088be8088c9547362d7 ;;
-    opam-2.1.2-i686-linux)      sha512=85a480d60e09a7d37fa0d0434ed97a3187434772ceb4e7e8faa5b06bc18423d004af3ad5849c7d35e72dca155103257fd6b1178872df8291583929eb8f884b6a ;;
-    opam-2.1.2-x86_64-freebsd)  sha512=50abe8d91bc2fde43565f40d12ff18a1eceaad51483db3d7c6619bce70920d0a3845fad8993b8bfad24c9d550c4b6a5c12d55fb8a5f26c0da25f221b68307f4b ;;
-    opam-2.1.2-x86_64-linux)    sha512=c0657ecbd4dc212587a4da70c5ff0402df95d148867be0e1eb1be8863a2851015f191437c3c99b7c2b153fcaa56cac99169c76ec94c5787750d7a59cd1fbb68b ;;
-    opam-2.1.2-x86_64-macos)    sha512=5ec63f3e4e4e93decb7580d0a114d3ab5eab49baea29edd80c8b4c86b7ab5224e654035903538ef4b63090ab3c2967d6efcc46bf0e8abf239ecc3e04ad7304e2 ;;
-    opam-2.1.2-x86_64-openbsd)  sha512=7c16d69c3bb655a149511218663aebdca54f9dd4346f8e4770f2699ae9560651ac242eb7f7aa94b21ad1b579bd857143b6f1ef98b0a53bd3c7047f13fcf95219 ;;
+    opam-2.1.3-arm64-linux)     sha512=6c495ed1ebb63eeb3b4a07068df97673dd9520c4474e480102412c23eb35e796a237680df3e0905faade190ead69c67be8f3a92e78944c2896e3546dfa68361d ;;
+    opam-2.1.3-arm64-macos)     sha512=abd834a078c6c783fa021f63ff17e5d4e3c8af833bcc276995f73c2d9af446b68ed8132bc344c791ce78afae980b6a6ca6ad0cea599076216deb5fe34e032250 ;;
+    opam-2.1.3-armhf-linux)     sha512=303e7e71daa3e678f6aed025a1ff5b4fbc1d3146dcda0d0ae91884d3ccce4b205d1a4d283005b63a3990ea4452df291f2e84d144ca13bc40373bcb46ee702690 ;;
+    opam-2.1.3-i686-linux)      sha512=b6834a54294c864069e70d0a46346fd4166c6847985f751c02a8c00184fc346095cbced3ded0aa34d710e1a68d687f5ca3ad8df4a2eea3c681727f5d1c0b099c ;;
+    opam-2.1.3-x86_64-freebsd)  sha512=0cf37cb5f7ca95706bacaf8340abd00901b3a7c7bfba4af1ba77f5740614e1e5227f9632be0427f1efdf8ed324c21efe412bf7f3a725afa84ac7f7339c4b5cbd ;;
+    opam-2.1.3-x86_64-linux)    sha512=b02e49f062291d6adf97a4e0ab3774f5ecb886d5ff73e693773493249f26aaa11b1cb1987ecf5074ce431fc34bacdc359a560d75ecc9bb4853f564489194b43b ;;
+    opam-2.1.3-x86_64-macos)    sha512=0d820ba42f34e6e3cfc6ac145794fb02b919f7c7086d9c6fb92489ddf11ab42d718753c9f84275f553832536216b66ee1bb57e93d08fc658cf0a82678df5be42 ;;
+    opam-2.1.3-x86_64-openbsd)  sha512=dc4479ca27baaa1b596451768cfeaeca35a87321a9938d3ecb3e3247adbc814da400667a864ba4d8cbffa665b72dc9e55aa7d3410a5caa8b82b4dc04991e5f77 ;;
     *)
       echo "Cannot install opam for \$targetos \$targetarch." >&2
       echo "Opam is required to setup the platform. Please install it via your package manager or obtain it at https://opam.ocaml.org/" >&2
@@ -96,7 +96,7 @@ install_opam ()
   check_sha512 "\$sha512" opam
 
   echo "=> Install into \$PREFIX/bin"
-  install -m755 "opam" "\$PREFIX/bin"
+  sudo install -m755 "opam" "\$PREFIX/bin"
 }
 
 cd "\$(mktemp -d)"
@@ -107,7 +107,7 @@ check_sha512 "\$sha512" "\$archive"
 tar xf "\$archive"
 
 echo "=> Install into \$PREFIX/bin"
-install -m755 bin/* "\$PREFIX/bin"
+sudo install -m755 bin/* "\$PREFIX/bin"
 
 # Install Opam if necessary
 if ! [[ -e \$PREFIX/bin/opam ]]; then


### PR DESCRIPTION
Currently, we hardcode in the installer script the version of the opam binary to install.

Although I think this should change, as a quick patch, this PR bumps this hardcoded version from 2.1.2 to 2.1.3.