### PR TITLE
Improving logging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- Display version to be installed and whether a package needs to be built in the
+  logs (#103)
 - Log before initialising Opam (#93)
 - Use OPAMCLI environment variable set to "2.0" to force the CLI version of
   future opam version. (#92)


### PR DESCRIPTION
With a mix of situation:
```
user@fc1c861174f2:~$ ocaml-platform 
* Inferring tools version...
  -> dune is already installed
  -> dune-release.1.6.2 will be installed from cache
  -> merlin.3.8.0 will be installed from cache
  -> ocaml-lsp-server is already installed
  -> odoc.2.1.1 will be built from source
  -> ocamlformat.0.24.1 will be installed from cache
* Building the tools...
  -> Creating a sandbox...
  -> [1/1] Building odoc...
* Installing tools...
  -> The tools have been installed. For more information on the platform tools, run `ocaml-platform --help`
* Success.
```
The main differences are:
- There is a mention whether it is "built from source" or "installed from cache"
- The version is given instead of the (somehow internal) binary package name. The `+bin+platform` explanation can still be found in the README.