### PR TITLE
Support compilers pinned or from ocaml-variants

### DIFF
--- a/src/lib/opam.mli
+++ b/src/lib/opam.mli
@@ -86,6 +86,10 @@ module Show : sig
     GlobalOpts.t -> string -> (string list, [> `Msg of string ]) result
 end
 
+module Exec : sig
+  val run : GlobalOpts.t -> Bos.Cmd.t -> (string, [> Rresult.R.msg ]) result
+end
+
 val install : GlobalOpts.t -> string list -> (unit, [> `Msg of string ]) result
 (** [install opam_opts atoms] installs the [atoms] into the current local
     switch. If opam has not been initialised, or if their is no local switch

--- a/src/lib/sandbox_compiler_package.ml
+++ b/src/lib/sandbox_compiler_package.ml
@@ -70,9 +70,12 @@ let extra_file =
   close_out oc
 |}
 
-(** The [~alpha...] suffix needs to be removed when overriding the [ocaml]
-    package. *)
-let remove_alpha_suffix ver =
+(** The [~alpha...] or [+...] or both suffixes needs to be removed when
+    overriding the [ocaml] package. *)
+let remove_alpha_plus_suffix ver =
+  let ver =
+    match String.cut ~sep:"+" ver with Some (pre, _) -> pre | None -> ver
+  in
   match String.cut ~sep:"~" ver with Some (pre, _) -> pre | None -> ver
 
 (** Lookup in the selected switch. *)
@@ -131,7 +134,9 @@ let init_pkg_ocaml_system repo ~ocaml_version =
     which disallow [~] suffixes. The [ocaml] package itself must not use a [~]
     suffix. *)
 let init_pkg_ocaml opam_opts repo ~ocaml_version =
-  let pkg = Package.v ~name:"ocaml" ~ver:(remove_alpha_suffix ocaml_version) in
+  let pkg =
+    Package.v ~name:"ocaml" ~ver:(remove_alpha_plus_suffix ocaml_version)
+  in
   if Repo.has_pkg repo pkg then Ok ()
   else
     let* opam_file = lookup_ocaml_descr opam_opts in

--- a/src/lib/sandbox_switch.ml
+++ b/src/lib/sandbox_switch.ml
@@ -95,7 +95,7 @@ let init opam_opts ~ocaml_version =
     let* () =
       Opam.Repository.add sandbox_opts ~path:(Repo.path repo) (Repo.name repo)
     in
-    Opam.install sandbox_opts [ "ocaml-system" ]
+    Opam.install sandbox_opts [ "ocaml-system." ^ ocaml_version ]
   in
   let* prefix = Opam.Config.Var.get sandbox_opts "prefix" >>| Fpath.v in
   Ok { sandbox_opts; sandbox_root; prefix; compiler_path }

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -103,10 +103,7 @@ let make_binary_package opam_opts ~ocaml_version sandbox repo bname tool =
 (** This version is used to select the highest available version of the tools
     and also to override the [ocaml-system] package declaration in the sandbox. *)
 let installed_ocaml_version opam_opts =
-  let* ocaml_comp_ver = Opam.Config.Var.get opam_opts "ocaml:compiler" in
-  match ocaml_comp_ver with
-  | "system" -> Opam.Config.Var.get opam_opts "ocaml-system:version"
-  | o -> Ok o
+  Opam.Exec.run opam_opts Bos.Cmd.(v "ocamlc" % "--version")
 
 let install opam_opts tools =
   let binary_repo_path =


### PR DESCRIPTION
The versions given to the packages needed to be more precise:
- `ocaml-system` needs a version given by `ocamlc --version`
- `ocaml` needs to remove both the `~` and the `+` suffixes.

I still need to add tests but this time the approach seems better to me.