### PR TITLE
Support all compilers, caching only unpinned standard ones

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- `ocaml-platform` will now work with `ocaml-variants`, pinned and other
+  compilers. It won't used the cache for pinned or custom compilers. (#106)
 - Display version to be installed and whether a package needs to be built in the
   logs (#103)
 - Log before initialising Opam (#93)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@
 
 ## unreleased
 
-- `ocaml-platform` will now work with `ocaml-variants`, pinned and other
-  compilers. It won't used the cache for pinned or custom compilers. (#106)
+- `ocaml-platform` will now work with all common compiler packages, skipping the
+  cache for pinned one. it will fail with a friendly error message for very
+  uncommon one. (#106)
 - Display version to be installed and whether a package needs to be built in the
   logs (#103)
 - Log before initialising Opam (#93)

--- a/src/lib/opam.ml
+++ b/src/lib/opam.ml
@@ -96,6 +96,16 @@ module Cmd = struct
 
   (** Like [run_s] but handle the "not found" status. *)
   let run_s_opt opam_opts cmd = run_gen opam_opts (out_s, out_opt) cmd
+
+  (** Like [run_s] but check that the output doesn't contain more than one line.
+      Returns an error otherwise. Returns [Ok None] if the output is empty. *)
+  let run_1l opam_opts cmd =
+    let* output = run_l opam_opts cmd in
+    match output with
+    | [] -> Ok None
+    | [ s ] -> Ok (Some s)
+    | _ :: _ :: _ ->
+        Result.errorf "Command '%a' returned unexpected output" Bos.Cmd.pp cmd
 end
 
 module Config = struct
@@ -216,7 +226,7 @@ end
 
 module List_ = struct
   let compiler opam_opts () =
-    Cmd.run_s opam_opts
+    Cmd.run_1l opam_opts
       Bos.Cmd.(
         v "list" % "--field-match=conflict-class:ocaml-core-compiler"
         % "--installed" % "--short")

--- a/src/lib/opam.ml
+++ b/src/lib/opam.ml
@@ -215,9 +215,11 @@ module Show = struct
 end
 
 module List_ = struct
-  let compilers opam_opts () =
-    Cmd.run_l opam_opts
-      Bos.Cmd.(v "list" % "--has-flag" % "compiler" % "--installed" % "--short")
+  let compiler opam_opts () =
+    Cmd.run_s opam_opts
+      Bos.Cmd.(
+        v "list" % "--field-match=conflict-class:ocaml-core-compiler"
+        % "--installed" % "--short")
 end
 
 let install opam_opts pkgs =

--- a/src/lib/opam.ml
+++ b/src/lib/opam.ml
@@ -208,7 +208,16 @@ module Show = struct
     Cmd.run_l opam_opts Bos.Cmd.(v "show" % "-f" % "depends:" % pkg_name)
 
   let version opam_opts pkg_name =
-    Cmd.run_l opam_opts Bos.Cmd.(v "show" % "-f" % "version" % pkg_name)
+    Cmd.run_s opam_opts Bos.Cmd.(v "show" % "-f" % "version" % pkg_name)
+
+  let pin opam_opts pkg_name =
+    Cmd.run_s opam_opts Bos.Cmd.(v "show" % "-f" % "pin" % pkg_name)
+end
+
+module List_ = struct
+  let compilers opam_opts () =
+    Cmd.run_l opam_opts
+      Bos.Cmd.(v "list" % "--has-flag" % "compiler" % "--installed" % "--short")
 end
 
 let install opam_opts pkgs =

--- a/src/lib/opam.mli
+++ b/src/lib/opam.mli
@@ -87,8 +87,7 @@ module Show : sig
 end
 
 module List_ : sig
-  val compilers :
-    GlobalOpts.t -> unit -> (string list, [> `Msg of string ]) result
+  val compiler : GlobalOpts.t -> unit -> (string, [> `Msg of string ]) result
 end
 
 val install : GlobalOpts.t -> string list -> (unit, [> `Msg of string ]) result

--- a/src/lib/opam.mli
+++ b/src/lib/opam.mli
@@ -82,11 +82,8 @@ module Show : sig
   val depends :
     GlobalOpts.t -> string -> (string list, [> `Msg of string ]) result
 
-  val version :
-    GlobalOpts.t -> string -> (string, [> `Msg of string ]) result
-
-  val pin :
-    GlobalOpts.t -> string -> (string, [> `Msg of string ]) result
+  val version : GlobalOpts.t -> string -> (string, [> `Msg of string ]) result
+  val pin : GlobalOpts.t -> string -> (string, [> `Msg of string ]) result
 end
 
 module List_ : sig

--- a/src/lib/opam.mli
+++ b/src/lib/opam.mli
@@ -87,7 +87,8 @@ module Show : sig
 end
 
 module List_ : sig
-  val compiler : GlobalOpts.t -> unit -> (string, [> `Msg of string ]) result
+  val compiler :
+    GlobalOpts.t -> unit -> (string option, [> `Msg of string ]) result
 end
 
 val install : GlobalOpts.t -> string list -> (unit, [> `Msg of string ]) result

--- a/src/lib/opam.mli
+++ b/src/lib/opam.mli
@@ -83,7 +83,15 @@ module Show : sig
     GlobalOpts.t -> string -> (string list, [> `Msg of string ]) result
 
   val version :
-    GlobalOpts.t -> string -> (string list, [> `Msg of string ]) result
+    GlobalOpts.t -> string -> (string, [> `Msg of string ]) result
+
+  val pin :
+    GlobalOpts.t -> string -> (string, [> `Msg of string ]) result
+end
+
+module List_ : sig
+  val compilers :
+    GlobalOpts.t -> unit -> (string list, [> `Msg of string ]) result
 end
 
 val install : GlobalOpts.t -> string list -> (unit, [> `Msg of string ]) result

--- a/src/lib/sandbox_compiler_package.ml
+++ b/src/lib/sandbox_compiler_package.ml
@@ -21,7 +21,7 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 build: ["ocaml" "gen_ocaml_config.ml"]
 substs: "gen_ocaml_config.ml"
-extra-files: ["gen_ocaml_config.ml.in" "md5=093e7bec1ec95f9e4c6a313d73c5d840"]
+extra-files: ["gen_ocaml_config.ml.in" "md5=c2a459eda2f5a95e67cd4114447b8a1b"]
 |}
 
 let extra_file =
@@ -35,15 +35,6 @@ let extra_file =
       else
         (s, "") in
     base ^ "c" ^ suffix in
-  if Sys.ocaml_version <> "%{_:version}%" then
-    (Printf.eprintf
-       "ERROR: The compiler found at %%s has version %%s,\n\
-        and this package requires %{_:version}%.\n\
-        You should use e.g. 'opam switch create %{_:name}%.%%s' \
-        instead."
-       ocamlc Sys.ocaml_version Sys.ocaml_version;
-     exit 1)
-  else
   let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
   let libdir =
     if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
@@ -70,48 +61,11 @@ let extra_file =
   close_out oc
 |}
 
-(** The [~alpha...] suffix needs to be removed when overriding the [ocaml]
+(** The [~alpha...+...] suffix needs to be removed when overriding the [ocaml]
     package. *)
-let remove_alpha_suffix ver =
-  match String.cut ~sep:"~" ver with Some (pre, _) -> pre | None -> ver
-
-(** Lookup in the selected switch. *)
-let lookup_ocaml_descr opam_opts = Opam.Show.opam_file opam_opts ~pkg:"ocaml"
-
-(** Fix [ocaml]'s constraint on [ocaml-system], which disallow alpha versions. *)
-let fix_ocaml_constraints opam_file ~ocaml_version =
-  let open OpamParserTypes.FullPos in
-  let with_pos f wp = { wp with pelem = f wp.pelem } in
-  let fake_pos pelem =
-    { pelem; pos = { filename = ""; start = (0, 0); stop = (0, 0) } }
-  in
-  let name_is_ocaml t =
-    match t.pelem with String "ocaml-system" -> true | _ -> false
-  in
-  let rec fix_depend = function
-    | Option (name, _args) when name_is_ocaml name ->
-        let cnstr =
-          Prefix_relop (fake_pos `Eq, fake_pos (String ocaml_version))
-        in
-        Option (name, fake_pos [ fake_pos cnstr ])
-    | Logop (op, left, right) ->
-        Logop (op, with_pos fix_depend left, with_pos fix_depend right)
-    | t -> t
-  in
-  let fix_depends = function
-    | List elems -> List (with_pos (List.map (with_pos fix_depend)) elems)
-    | t -> t
-  in
-  let fix_item = function
-    | Variable (({ pelem = "depends"; _ } as name), value) ->
-        Variable (name, with_pos fix_depends value)
-    | t -> t
-  in
-  let fix_opamfile t =
-    { t with file_contents = List.map (with_pos fix_item) t.file_contents }
-  in
-  OpamParser.FullPos.string opam_file "ocaml"
-  |> fix_opamfile |> OpamPrinter.FullPos.opamfile
+let remove_alpha_plus_suffix ver =
+  let cut sep s = match String.cut ~sep s with Some (s, _) -> s | None -> s in
+  cut "+" (cut "~" ver)
 
 (** Override the [ocaml-system] package to drop the [sys-ocaml-version]
     constraint and to specify the right version for it, for example
@@ -127,23 +81,12 @@ let init_pkg_ocaml_system repo ~ocaml_version =
     let extra_files = [ ("gen_ocaml_config.ml.in", extra_file) ] in
     Repo.add_package repo pkg ~extra_files ~install_file opam_file
 
-(** Override the [ocaml] package to fix the dependency it has on [ocaml-system],
-    which disallow [~] suffixes. The [ocaml] package itself must not use a [~]
-    suffix. *)
-let init_pkg_ocaml opam_opts repo ~ocaml_version =
-  let pkg = Package.v ~name:"ocaml" ~ver:(remove_alpha_suffix ocaml_version) in
-  if Repo.has_pkg repo pkg then Ok ()
-  else
-    let* opam_file = lookup_ocaml_descr opam_opts in
-    let opam_file = fix_ocaml_constraints opam_file ~ocaml_version in
-    Repo.add_package repo pkg (Package.Opam_file.of_string opam_file)
-
 let init opam_opts ocaml_version =
+  let ocaml_version = remove_alpha_plus_suffix ocaml_version in
   let name = "platform_sandbox_compiler_packages" in
   let path =
     Fpath.(opam_opts.Opam.GlobalOpts.root / "plugins" / "ocaml-platform" / name)
   in
   let* repo = Repo.init ~name path in
   let* () = init_pkg_ocaml_system repo ~ocaml_version in
-  let* () = init_pkg_ocaml opam_opts repo ~ocaml_version in
-  Ok repo
+  Ok (repo, "ocaml-system."^ocaml_version)

--- a/src/lib/sandbox_compiler_package.ml
+++ b/src/lib/sandbox_compiler_package.ml
@@ -89,4 +89,4 @@ let init opam_opts ocaml_version =
   in
   let* repo = Repo.init ~name path in
   let* () = init_pkg_ocaml_system repo ~ocaml_version in
-  Ok (repo, "ocaml-system."^ocaml_version)
+  Ok (repo, "ocaml-system." ^ ocaml_version)

--- a/src/lib/sandbox_compiler_package.mli
+++ b/src/lib/sandbox_compiler_package.mli
@@ -1,5 +1,5 @@
 open Import
 
-val init : Opam.GlobalOpts.t -> string -> (Repo.t, 'e) Result.or_msg
+val init : Opam.GlobalOpts.t -> string -> (Repo.t * string, 'e) Result.or_msg
 (** [init opam_opts ocaml_version] creates (if needed) a repo containing a
     patched version of [ocaml-system] working well with the sandbox switch. *)

--- a/src/lib/sandbox_switch.ml
+++ b/src/lib/sandbox_switch.ml
@@ -91,7 +91,9 @@ let init opam_opts ~ocaml_version =
       Opam.Switch.create ~ocaml_version:None opam_opts
         (Fpath.to_string sandbox_root)
     in
-    let* repo, compiler_package = Sandbox_compiler_package.init opam_opts ocaml_version in
+    let* repo, compiler_package =
+      Sandbox_compiler_package.init opam_opts ocaml_version
+    in
     let* () =
       Opam.Repository.add sandbox_opts ~path:(Repo.path repo) (Repo.name repo)
     in

--- a/src/lib/sandbox_switch.ml
+++ b/src/lib/sandbox_switch.ml
@@ -91,11 +91,11 @@ let init opam_opts ~ocaml_version =
       Opam.Switch.create ~ocaml_version:None opam_opts
         (Fpath.to_string sandbox_root)
     in
-    let* repo = Sandbox_compiler_package.init opam_opts ocaml_version in
+    let* repo, compiler_package = Sandbox_compiler_package.init opam_opts ocaml_version in
     let* () =
       Opam.Repository.add sandbox_opts ~path:(Repo.path repo) (Repo.name repo)
     in
-    Opam.install sandbox_opts [ "ocaml-system" ]
+    Opam.install sandbox_opts [ compiler_package ]
   in
   let* prefix = Opam.Config.Var.get sandbox_opts "prefix" >>| Fpath.v in
   Ok { sandbox_opts; sandbox_root; prefix; compiler_path }

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -113,7 +113,8 @@ let get_compiler_pkg opam_opts =
       let* ver = Opam.Show.version opam_opts name in
       let* pin = Opam.Show.pin opam_opts name in
       Ok (Package.v ~name ~ver, pin <> "")
-  | Some name -> R.error_msgf "Cannot install tools for compilers '%s'" name
+  | Some name ->
+      R.error_msgf "Installing tools for compiler '%s' is not supported." name
   | None -> R.error_msgf "No compiler installed in your current switch."
 
 let install opam_opts tools =

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -161,7 +161,7 @@ let install opam_opts tools =
                     ~ver:best_version ~pure_binary:tool.pure_binary
                 in
                 let to_build, action_s =
-                  if Binary_repo.has_binary_pkg repo bname && should_use_cache
+                  if should_use_cache && Binary_repo.has_binary_pkg repo bname
                   then (to_build, "installed from cache")
                   else ((tool, bname) :: to_build, "built from source")
                 in

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -108,11 +108,13 @@ let make_binary_package opam_opts ~ocaml_version sandbox repo bname tool =
 let get_compiler_pkg opam_opts =
   let* name = Opam.List_.compiler opam_opts () in
   match name with
-  | "ocaml-system" | "ocaml-variants" | "ocaml-base-compiler" ->
+  | Some (("ocaml-system" | "ocaml-variants" | "ocaml-base-compiler") as name)
+    ->
       let* ver = Opam.Show.version opam_opts name in
       let* pin = Opam.Show.pin opam_opts name in
       Ok (Package.v ~name ~ver, pin <> "")
-  | _ -> R.error_msgf "Cannot install tools for compilers '%s'" name
+  | Some name -> R.error_msgf "Cannot install tools for compilers '%s'" name
+  | None -> R.error_msgf "No compiler installed in your current switch."
 
 let install opam_opts tools =
   let binary_repo_path =


### PR DESCRIPTION
This replace #105.

- We only use the cache in the following case: the compiler package is one of the standard ones (`ocaml-base-compiler`, `ocaml-system` and `ocaml-variants`), and it is unpinned.
- We use the unsuffixed version for the `ocaml-system` sandbox switch package, and disable version check (anyway, there is an uncertainty to me on what will be the value of `Sys.ocaml_version`: on `ocaml-variants.4.14.0~rc2+options` it is `4.14.0~rc2`, while the [doc](https://v2.ocaml.org/api/Sys.html#VALocaml_version) of `Sys.ocaml_version` says that `+` suffixes can be outputted).
- Using the unsuffixed `ocaml-system` package version allows us to avoid patching the `ocaml` package, simplifying the code a lot. Anyway, the package contents did not depends on the suffixes...
- Note that if we overrided the original package (that is, sometimes `ocaml-base-compiler` or `ocaml-variants`) instead of always the `ocaml-system` package, then the installation of `ocamlfind` would fail with a problem similar to [this one](https://discuss.ocaml.org/t/problem-installing-ocamlfind-on-latest-ocamlpro-alpine-docker-image/10147).

We also log when we encounter a pinned package, eg:
```
$  ocaml-platform    
* Pinned compiler detected. No cache will be used.
* Inferring tools version...
  -> dune is already installed
  -> dune-release.1.6.2 will be built from source
  -> merlin.4.6-414 will be built from source
  -> ocaml-lsp-server.1.13.1 will be built from source
  -> odoc.2.1.1 will be built from source
  -> ocamlformat.0.24.1 will be built from source
* Building the tools...
  -> Creating a sandbox...
^CUser interruption
```