### PR TITLE
Do not distinguish between ocaml version in cache when unnecessary

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,6 +79,10 @@ jobs:
         if: ${{matrix.platform.target_arch == 'x86_64'}}
         run: ./test/run_test.sh reinstall_ocamlformat
 
+      - name: "Test: version dependency"
+        if: ${{matrix.platform.target_arch == 'x86_64'}}
+        run: ./test/run_test.sh version_dependent
+
       - name: Build release tarball
         if: startsWith(github.ref, 'refs/tags/')
         run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 - Force the installed version to match the best version available for a compiler
   version. (#112)
+- Separate between packages that depends or not on the ocaml version used to
+  compile them. When they do not depend on it, use a single entry per package
+  version in the cache (#110).
 
 ## 0.4.0 (2022-09-26)
 

--- a/src/lib/binary_repo/binary_package.mli
+++ b/src/lib/binary_repo/binary_package.mli
@@ -10,6 +10,7 @@ val binary_name :
   name:string ->
   ver:string ->
   pure_binary:bool ->
+  ocaml_version_dependent:bool ->
   full_name
 
 val to_string : full_name -> string
@@ -20,7 +21,7 @@ val package : full_name -> Package.full_name
 type binary_pkg = Package.Install_file.t * Package.Opam_file.t
 
 val make_binary_package :
-  ocaml_version:string ->
+  ocaml_version:string option ->
   arch:string ->
   os_distribution:string ->
   prefix:Fpath.t ->

--- a/src/lib/binary_repo/package.ml
+++ b/src/lib/binary_repo/package.ml
@@ -30,17 +30,24 @@ module Opam_file = struct
   let list l = with_pos @@ List (with_pos l)
   let option v l = with_pos @@ Option (v, with_pos l)
 
-  type atom = [ `Eq | `Geq | `Gt | `Leq | `Lt | `Neq ] * string * string
+  type atom =
+    string * ([ `Eq | `Geq | `Gt | `Leq | `Lt | `Neq ] * string) option
+
   type formula = Atom of atom | Formula of [ `And | `Or ] * formula * formula
 
-  let available_atom (op, a, b) =
-    with_pos @@ Relop (with_pos op, ident a, string b)
+  let available_atom (a, cst) =
+    match cst with
+    | None -> string a
+    | Some (op, b) -> with_pos @@ Relop (with_pos op, ident a, string b)
 
-  let dependency_atom (op, a, b) =
-    with_pos
-    @@ Option
-         ( string a,
-           with_pos [ with_pos @@ Prefix_relop (with_pos op, string b) ] )
+  let dependency_atom (a, cst) =
+    match cst with
+    | None -> string a
+    | Some (op, b) ->
+        with_pos
+        @@ Option
+             ( string a,
+               with_pos [ with_pos @@ Prefix_relop (with_pos op, string b) ] )
 
   let rec formula atom f =
     match f with

--- a/src/lib/binary_repo/package.mli
+++ b/src/lib/binary_repo/package.mli
@@ -13,7 +13,8 @@ module Opam_file : sig
   type t
   type cmd = string list
 
-  type atom = [ `Eq | `Geq | `Gt | `Leq | `Lt | `Neq ] * string * string
+  type atom =
+    string * ([ `Eq | `Geq | `Gt | `Leq | `Lt | `Neq ] * string) option
   (** [operator * var_name * constraint] *)
 
   type formula = Atom of atom | Formula of [ `And | `Or ] * formula * formula

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -129,7 +129,8 @@ let install opam_opts tools =
   let should_use_cache =
     (* We only use the cache when it is a regular unpinned compiler *)
     if pinned then
-      Logs.app (fun m -> m "* Pinned compiler detected. No cache will be used.");
+      Logs.app (fun m ->
+          m "* Pinned compiler detected. Disable cache for some package.");
     not pinned
   in
   let ocaml_version = Package.ver compiler_pkg in
@@ -159,7 +160,9 @@ let install opam_opts tools =
                     ~pure_binary ~ocaml_version_dependent
                 in
                 let to_build, action_s =
-                  if should_use_cache && Binary_repo.has_binary_pkg repo bname
+                  if
+                    (should_use_cache || tool.ocaml_version_dependent)
+                    && Binary_repo.has_binary_pkg repo bname
                   then (to_build, "installed from cache")
                   else
                     let build sandbox =

--- a/test/dockerfiles/Dockerfile.version_dependent
+++ b/test/dockerfiles/Dockerfile.version_dependent
@@ -1,0 +1,11 @@
+ARG TARGETPLATFORM=$TARGETPLATFORM
+
+FROM ocaml-platform-build-$TARGETPLATFORM:latest as base
+
+FROM ocaml-platform-install-$TARGETPLATFORM:latest
+
+COPY --from=base /usr/local/bin/ocaml-platform /usr/local/bin/ocaml-platform
+
+COPY test/tests/version_dependent.sh .
+
+RUN bash version_dependent.sh

--- a/test/tests/version_dependent.sh
+++ b/test/tests/version_dependent.sh
@@ -1,0 +1,32 @@
+#/usr/bin/env bash
+set -euo pipefail
+
+# The setting of this test should be the end of the "install" test. That is, the
+# current switch should be of version 4.08 with the installer having run.
+
+# The installed version of these tools should be tied to 4.08.1, as they are
+# dependent on the version of OCaml they were compiled with.
+[[ $(opam show dune -f depends: ) =~ "4.08.1" ]]
+[[ $(opam show merlin+bin+platform -f depends: ) =~ "4.08.1" ]]
+[[ $(opam show ocaml-lsp-server+bin+platform -f depends: ) =~ "4.08.1" ]]
+[[ $(opam show odoc+bin+platform -f depends: ) =~ "4.08.1" ]]
+
+# The installed version of these tools should not be tied to 4.08.1, as they are
+# is independent from the version of OCaml they were compiled with.
+[[ $(opam show dune-release+bin+platform -f depends: ) != *"4.08.1"* ]]
+[[ $(opam show ocamlformat+bin+platform -f depends: ) != *"4.08.1"* ]]
+
+# Now, we check that the installation still works well on 4.13
+
+opam switch create 4.13.1
+
+eval $(opam env)
+
+ocaml-platform
+
+opam --version
+dune --version
+dune-release --version
+dune ocaml-merlin --version
+odoc --version
+ocamlformat --version


### PR DESCRIPTION
Some tools are not sensitive to ocaml version (currently, `ocamlformat` and `dune-release`). However, they were built once per ocaml version in the cache. This commit makes a difference between those two types of tools, and for the insensitive ones, do not depend on the ocaml version.

This makes a very clear speed boost, especially for packages that are long to install (e.g. `ocamlformat`) and opens the possibility to add more (as in #107) without too much speed lost. 