### PR TITLE
Force the installed version to match the computed best version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+- Force the installed version to match the best version available for a compiler
+  version. (#112)
+
 ## 0.4.0 (2022-09-26)
 
 - `ocaml-platform` will now work with all common compiler packages, skipping the

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -157,7 +157,7 @@ let install opam_opts tools =
                 let to_build, action_s =
                   if should_use_cache && Binary_repo.has_binary_pkg repo bname
                   then (to_build, "installed from cache")
-                  else ((tool, bname) :: to_build, "built from source")
+                  else (({tool with version = Some best_version}, bname) :: to_build, "built from source")
                 in
                 Logs.app (fun m ->
                     m "  -> %s.%s will be %s" tool.name best_version action_s);


### PR DESCRIPTION
This fixes #111, as it prevents the installation of a package to change the version of the ocaml package.

It is also good on itself as a fail-safe against having a mismatch between the actual version and the binary package version.

However, I think that we should still investigate why, as in #111, the ocaml package could be upgraded.