### PR TITLE
Use a temporary cache repo in case of pinned compiler

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,6 +83,10 @@ jobs:
         if: ${{matrix.platform.target_arch == 'x86_64'}}
         run: ./test/run_test.sh version_dependent
 
+      - name: "Test: pinned-compiler"
+        if: ${{matrix.platform.target_arch == 'x86_64'}}
+        run: ./test/run_test.sh pinned-compiler
+
       - name: Build release tarball
         if: startsWith(github.ref, 'refs/tags/')
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: "Test: install-in-small-project"
         if: ${{matrix.platform.target_arch == 'x86_64'}}
-        run: ./test/run_test.sh small-project install-in-small-project
+        run: ./test/run_test.sh install-in-small-project
 
       - name: "Test: odoc"
         if: ${{matrix.platform.target_arch == 'x86_64'}}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Avoid adding packages built with a pinned compiler into the cache. (#115)
 - Force the installed version to match the best version available for a compiler
   version. (#112)
 - Separate between packages that depends or not on the ocaml version used to

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -127,8 +127,7 @@ let get_cache_repo opam_opts ~pinned f =
   if pinned then (
     (* Pinned compiler: don't actually cache the result by using a temporary
        repository. *)
-    Logs.app (fun m ->
-        m "* Pinned compiler detected. Caching is disabled.");
+    Logs.app (fun m -> m "* Pinned compiler detected. Caching is disabled.");
     Result.join
     @@ OS.Dir.with_tmp "ocaml-platform-pinned-cache-%s"
          (fun tmp_path () ->
@@ -173,8 +172,8 @@ let install opam_opts tools =
                     ~pure_binary ~ocaml_version_dependent
                 in
                 let to_build, action_s =
-                  if Binary_repo.has_binary_pkg repo bname
-                  then (to_build, "installed from cache")
+                  if Binary_repo.has_binary_pkg repo bname then
+                    (to_build, "installed from cache")
                   else
                     let build sandbox =
                       let ocaml_version =

--- a/test/dockerfiles/Dockerfile.install
+++ b/test/dockerfiles/Dockerfile.install
@@ -7,16 +7,13 @@ FROM ubuntu:20.04
 RUN apt update
 RUN apt install -y gcc make patch unzip bubblewrap curl rsync opam
 
-COPY --from=base /usr/local/bin/ocaml-platform /usr/local/bin/ocaml-platform
-
 RUN useradd -ms /bin/bash user
-
 WORKDIR /home/user
-
 USER user
 
 RUN opam init --disable-sandboxing --yes
 
 COPY test/tests/install.sh .
+COPY --from=base /usr/local/bin/ocaml-platform /usr/local/bin/ocaml-platform
 
 RUN bash install.sh

--- a/test/dockerfiles/Dockerfile.install-in-small-project
+++ b/test/dockerfiles/Dockerfile.install-in-small-project
@@ -6,6 +6,8 @@ FROM ocaml-platform-small-project-$TARGETPLATFORM:latest
 
 COPY --from=base /usr/local/bin/ocaml-platform /usr/local/bin/ocaml-platform
 
+RUN opam switch create helloworld/ 4.13.1
+
 RUN true
     # https://stackoverflow.com/questions/51115856/docker-failed-to-export-image-failed-to-create-image-failed-to-get-layer
 

--- a/test/dockerfiles/Dockerfile.install-in-small-project
+++ b/test/dockerfiles/Dockerfile.install-in-small-project
@@ -1,12 +1,14 @@
 ARG TARGETPLATFORM=$TARGETPLATFORM
-
 FROM ocaml-platform-build-$TARGETPLATFORM:latest as base
+FROM ocaml/opam:ubuntu-ocaml-4.13
 
-FROM ocaml-platform-small-project-$TARGETPLATFORM:latest
+COPY test/tests/small-project.sh .
+RUN bash small-project.sh
+WORKDIR helloworld
+
+RUN opam switch create . 4.13.1
 
 COPY --from=base /usr/local/bin/ocaml-platform /usr/local/bin/ocaml-platform
-
-RUN opam switch create helloworld/ 4.13.1
 
 RUN true
     # https://stackoverflow.com/questions/51115856/docker-failed-to-export-image-failed-to-create-image-failed-to-get-layer

--- a/test/dockerfiles/Dockerfile.pinned-compiler
+++ b/test/dockerfiles/Dockerfile.pinned-compiler
@@ -1,0 +1,20 @@
+ARG TARGETPLATFORM=$TARGETPLATFORM
+FROM ocaml-platform-build-$TARGETPLATFORM:latest as base
+FROM ocaml/opam:ubuntu-ocaml-4.13
+
+COPY test/tests/pin-ocaml-compiler.sh .
+RUN bash pin-ocaml-compiler.sh
+
+COPY test/tests/small-project.sh .
+RUN bash small-project.sh
+WORKDIR helloworld
+
+COPY --from=base /usr/local/bin/ocaml-platform /usr/local/bin/ocaml-platform
+
+COPY test/tests/install.sh .
+RUN bash install.sh
+# Check that the tools are installed but don't appear in the cache
+COPY test/tests/version.sh .
+RUN bash version.sh
+COPY test/tests/check_cache_is_empty.sh .
+RUN bash check_cache_is_empty.sh

--- a/test/dockerfiles/Dockerfile.small-project
+++ b/test/dockerfiles/Dockerfile.small-project
@@ -1,9 +1,0 @@
-ARG TARGETPLATFORM=$TARGETPLATFORM
-
-FROM ocaml-platform-build-$TARGETPLATFORM:latest as base
-
-FROM ocaml/opam:ubuntu-ocaml-4.13
-
-COPY test/tests/small-project.sh .
-
-RUN bash small-project.sh

--- a/test/dockerfiles/Dockerfile.small-project
+++ b/test/dockerfiles/Dockerfile.small-project
@@ -7,5 +7,3 @@ FROM ocaml/opam:ubuntu-ocaml-4.13
 COPY test/tests/small-project.sh .
 
 RUN bash small-project.sh
-
-COPY --from=base /usr/local/bin/ocaml-platform /usr/local/bin/ocaml-platform

--- a/test/tests/check_cache_is_empty.sh
+++ b/test/tests/check_cache_is_empty.sh
@@ -1,0 +1,4 @@
+#/usr/bin/env bash
+set -euo pipefail
+
+[[ $(find $HOME/.opam/plugins/ocaml-platform/cache/archives) = "" ]]

--- a/test/tests/install-in-small-project.sh
+++ b/test/tests/install-in-small-project.sh
@@ -1,8 +1,6 @@
 #/usr/bin/env bash
 set -euo pipefail
 
-cd helloworld
-
 eval $(opam env)
 
 ocaml-platform -vv

--- a/test/tests/ocamlformat.sh
+++ b/test/tests/ocamlformat.sh
@@ -1,8 +1,6 @@
 #/usr/bin/env bash
 set -euo pipefail
 
-cd helloworld
-
 eval $(opam env)
 
 [[ $(ocamlformat --version) =~ "0.19.0" ]];

--- a/test/tests/odoc.sh
+++ b/test/tests/odoc.sh
@@ -1,8 +1,6 @@
 #/usr/bin/env bash
 set -euo pipefail
 
-cd helloworld
-
 eval $(opam env)
 
 dune build @doc

--- a/test/tests/pin-ocaml-compiler.sh
+++ b/test/tests/pin-ocaml-compiler.sh
@@ -1,0 +1,8 @@
+#/usr/bin/env bash
+set -euo pipefail
+
+cd $HOME
+git clone https://github.com/ocaml/ocaml
+cd ocaml
+opam switch create --empty pinned
+opam install .

--- a/test/tests/re-install-in-small-project.sh
+++ b/test/tests/re-install-in-small-project.sh
@@ -13,8 +13,6 @@ set -euo pipefail
 # - installing the tools on top of dependencies
 #     tools should not replace a package if it is installed
 
-cd helloworld
-
 eval $(opam env)
 
 # Checking that we start with the good environment

--- a/test/tests/small-project.sh
+++ b/test/tests/small-project.sh
@@ -10,9 +10,5 @@ dune init proj helloworld
 cd helloworld
 
 echo "version = 0.19.0" > .ocamlformat
-
 sed 's/depends ocaml dune/depends ocaml dune dune-release/g' dune-project > tmp_dune-project
-
 mv tmp_dune-project dune-project
-
-opam switch create . 4.13.1


### PR DESCRIPTION
Tools built on a pinned compilers need to be stored on a repository in order to be installed back in the user's switch. The cache repository was used for this, which contradicts the restriction that the cache isn't used with pinned compiler and might be unsafe.

Use a new temporary repository to make sure that these packages don't leak into the global cache. It is created on the fly and removed when it's no longer needed.

Packages that don't depend on the version of OCaml are no longer pulled from the cache in this case.
This could be added back with more code and more bugs. What do you think ?
