### PR TITLE
Use cache for packages independent from ocaml version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Pull packages that are independent of the ocaml version from the global cache
+  (#117)
+
 ## unreleased
 
 - Avoid adding packages built with a pinned compiler into the cache. (#115)

--- a/src/lib/binary_repo/binary_repo.ml
+++ b/src/lib/binary_repo/binary_repo.ml
@@ -3,9 +3,9 @@ open Rresult
 
 type t = { repo : Repo.t; archive : Fpath.t }
 
-let init base_path =
+let init ~name base_path =
   let repo_path = Fpath.(base_path / "repo") in
-  Repo.init ~name:"platform-cache" repo_path >>= fun repo ->
+  Repo.init ~name repo_path >>= fun repo ->
   let archive = Fpath.( / ) base_path "archives" in
   OS.Dir.create archive >>= fun _ -> Ok { repo; archive }
 

--- a/src/lib/binary_repo/binary_repo.mli
+++ b/src/lib/binary_repo/binary_repo.mli
@@ -5,7 +5,7 @@ open Bos
 
 type t
 
-val init : Fpath.t -> (t, 'e) OS.result
+val init : name:string -> Fpath.t -> (t, 'e) OS.result
 val repo : t -> Repo.t
 
 val archive_path : t -> Binary_package.full_name -> Fpath.t

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -137,7 +137,7 @@ let get_cache_repo opam_opts ~pinned f =
     @@ OS.Dir.with_tmp "ocaml-platform-pinned-cache-%s"
          (fun tmp_path () ->
            let* repo = Binary_repo.init tmp_path in
-           f repo global_repo)
+           f global_repo repo )
          ())
   else (* Otherwise, use the global cache. *)
     f global_repo global_repo

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -128,7 +128,9 @@ let get_cache_repo opam_opts ~pinned f =
     Fpath.(
       opam_opts.Opam.GlobalOpts.root / "plugins" / "ocaml-platform" / "cache")
   in
-  let* global_repo = Binary_repo.init global_binary_repo_path in
+  let* global_repo =
+    Binary_repo.init ~name:"platform-cache" global_binary_repo_path
+  in
   if pinned then (
     (* Pinned compiler: don't actually cache the result by using a temporary
        repository. *)
@@ -136,7 +138,10 @@ let get_cache_repo opam_opts ~pinned f =
     Result.join
     @@ OS.Dir.with_tmp "ocaml-platform-pinned-cache-%s"
          (fun tmp_path () ->
-           let* repo = Binary_repo.init tmp_path in
+           let name =
+             "ocaml-platform-pinned-cache-" ^ Fpath.to_string tmp_path
+           in
+           let* repo = Binary_repo.init ~name tmp_path in
            f ~global_repo ~push_repo:repo [ global_repo; repo ])
          ())
   else

--- a/test/tests/check_cache_is_empty.sh
+++ b/test/tests/check_cache_is_empty.sh
@@ -1,4 +1,9 @@
 #/usr/bin/env bash
 set -euo pipefail
 
-[[ $(find $HOME/.opam/plugins/ocaml-platform/cache/archives) = "" ]]
+[[ $(find $HOME/.opam/plugins/ocaml-platform/cache/archives/odoc+bin+platform) = "" ]]
+[[ $(find $HOME/.opam/plugins/ocaml-platform/cache/archives/dune) = "" ]]
+[[ $(find $HOME/.opam/plugins/ocaml-platform/cache/archives/merlin+bin+platform) = "" ]]
+[[ $(find $HOME/.opam/plugins/ocaml-platform/cache/archives/ocaml-lsp-server+bin+platform) = "" ]]
+[[ $(find $HOME/.opam/plugins/ocaml-platform/cache/archives/ocamlformat+bin+platform) = "" ]]
+[[ $(find $HOME/.opam/plugins/ocaml-platform/cache/archives/dune-release+bin+platform) = "" ]]


### PR DESCRIPTION
Fix "regression" introduced in #115.

We need to verify that the packages are taken first from `dependent_repo` and then from `independent_repo`.