### PR TITLE
Shorten install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The official guide [Up and Running with OCaml](https://ocaml.org/docs/up-and-run
 This set-up goes through several steps, some of which have to be redone for every new project. The `ocaml-platform` binary, automates and speeds those steps. However, you still need first to install the few dependencies of the OCaml environment, such as a C compiler (such as `gcc`) and other system tools: `bzip2`, `make`, `bubblewrap`, `patch`, `curl` and `unzip`. In most architecture, you can install them using your package manager, for example on Ubuntu or Debian:
 
 ``` sh
-sudo apt install build-essential bubblewrap unzip
+sudo apt install build-essential rsync bubblewrap unzip
 ```
 
 You can now run the installer script (which will call `sudo` for the final installation step):

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ The official guide [Up and Running with OCaml](https://ocaml.org/docs/up-and-run
 This set-up goes through several steps, some of which have to be redone for every new project. The `ocaml-platform` binary, automates and speeds those steps. However, you still need first to install the few dependencies of the OCaml environment, such as a C compiler (such as `gcc`) and other system tools: `bzip2`, `make`, `bubblewrap`, `patch`, `curl` and `unzip`. In most architecture, you can install them using your package manager, for example on Ubuntu or Debian:
 
 ``` sh
-sudo apt install bzip2 make gcc bubblewrap rsync patch curl unzip
+sudo apt install build-essential bubblewrap unzip
 ```
 
 You can now run the installer script (which will call `sudo` for the final installation step):
 
 ```sh
-bash < <(curl -sL https://github.com/tarides/ocaml-platform-installer/releases/latest/download/installer.sh)
+wget https://github.com/tarides/ocaml-platform-installer/releases/latest/download/installer.sh -O - | bash
 ```
 
 Don't hesitate to have a look at what the script does.


### PR DESCRIPTION
In Ubuntu and Debian,  wget is preinstalled while curl is not. Use it and remove one dependency build-essential subsumes all remaining dependencies except bubblewrap and unzip