### PR TITLE
Don't skip installing if the installed version does not satisfy the request

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,6 +75,10 @@ jobs:
         if: ${{matrix.platform.target_arch == 'x86_64'}}
         run: ./test/run_test.sh ocamlformat
 
+      - name: "Test: ocamlformat_user_installed"
+        if: ${{matrix.platform.target_arch == 'x86_64'}}
+        run: ./test/run_test.sh ocamlformat_user_installed
+
       - name: "Test: reinstall_cached"
         if: ${{matrix.platform.target_arch == 'x86_64'}}
         run: ./test/run_test.sh reinstall_cached

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## unreleased
+
+- Fix OCamlformat is not installed to the right version if it was already
+  installed. (#127)
+
 ## 0.6.0 (2022-10-05)
 
 - Pull packages that are independent of the ocaml version from the global cache

--- a/src/lib/opam.ml
+++ b/src/lib/opam.ml
@@ -209,7 +209,7 @@ module Show = struct
           % "--normalise")
     in
     let+ res = parse res in
-    List.map (function a, "--" -> (a, None) | a, s -> (a, Some s)) res
+    List.filter_map (function _, "--" -> None | a, s -> Some (a, s)) res
 
   let opam_file opam_opts ~pkg =
     Cmd.run_s opam_opts Bos.Cmd.(v "show" % pkg % "-f" % "opam-file")

--- a/src/lib/opam.mli
+++ b/src/lib/opam.mli
@@ -73,9 +73,9 @@ module Show : sig
     GlobalOpts.t -> string -> (string option, [> `Msg of string ]) result
 
   val installed_versions :
-    GlobalOpts.t ->
-    string list ->
-    ((string * string option) list, 'a) Result.or_msg
+    GlobalOpts.t -> string list -> ((string * string) list, 'a) Result.or_msg
+  (** Query the installed version of a list of package. Packages that are not
+      installed don't appear in the result. *)
 
   val opam_file : GlobalOpts.t -> pkg:string -> (string, 'a) Result.or_msg
 

--- a/test/dockerfiles/Dockerfile.ocamlformat_user_installed
+++ b/test/dockerfiles/Dockerfile.ocamlformat_user_installed
@@ -1,14 +1,19 @@
 ARG TARGETPLATFORM=$TARGETPLATFORM
-
 FROM ocaml-platform-build-$TARGETPLATFORM:latest as base
+FROM ocaml/opam:ubuntu-ocaml-4.13
 
-FROM ocaml-platform-install-in-small-project-$TARGETPLATFORM:latest
+# Install a different version than in the script
+RUN opam install -y ocamlformat.0.23.0
+
+COPY test/tests/small-project.sh .
+RUN bash small-project.sh
+WORKDIR helloworld
 
 COPY --from=base /usr/local/bin/ocaml-platform /usr/local/bin/ocaml-platform
 
 RUN true
     # https://stackoverflow.com/questions/51115856/docker-failed-to-export-image-failed-to-create-image-failed-to-get-layer
 
-COPY test/tests/ocamlformat.sh .
+COPY test/tests/ocamlformat_user_installed.sh .
 
-RUN bash ocamlformat.sh
+RUN bash ocamlformat_user_installed.sh

--- a/test/dockerfiles/Dockerfile.ocamlformat_user_installed
+++ b/test/dockerfiles/Dockerfile.ocamlformat_user_installed
@@ -1,13 +1,10 @@
 ARG TARGETPLATFORM=$TARGETPLATFORM
 FROM ocaml-platform-build-$TARGETPLATFORM:latest as base
-FROM ocaml/opam:ubuntu-ocaml-4.13
+# Avoid rebuilding all the tools
+FROM ocaml-platform-install-in-small-project-$TARGETPLATFORM:latest
 
-# Install a different version than in the script
+# Install a different version than specified in the script
 RUN opam install -y ocamlformat.0.23.0
-
-COPY test/tests/small-project.sh .
-RUN bash small-project.sh
-WORKDIR helloworld
 
 COPY --from=base /usr/local/bin/ocaml-platform /usr/local/bin/ocaml-platform
 

--- a/test/tests/ocamlformat_user_installed.sh
+++ b/test/tests/ocamlformat_user_installed.sh
@@ -1,0 +1,13 @@
+#/usr/bin/env bash
+set -xeuo pipefail
+
+# OCamlformat is already installed but not to the right version.
+# The difference with the "reinstall_ocamlformat" is that ocamlformat is
+# initially installed from its upstream package.
+
+eval `opam env`
+
+! [[ $(ocamlformat --version) = 0.24.1 ]]
+echo "version = 0.24.1" > .ocamlformat
+ocaml-platform -vv
+[[ $(ocamlformat --version) = 0.24.1 ]]


### PR DESCRIPTION
Fix https://github.com/tarides/ocaml-platform-installer/issues/126

Installing a tool was skipped if it was already installed on the current switch, regardless of its required version.
This only affected ocamlformat.

I moved some code for readability, which was being re-indented anyway.
