### PR TITLE
Continue the process even if the build of a tool failed.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,6 +95,10 @@ jobs:
         if: ${{matrix.platform.target_arch == 'x86_64'}}
         run: ./test/run_test.sh pinned-compiler
 
+      - name: "Test: continue-when-build-fails"
+        if: ${{matrix.platform.target_arch == 'x86_64'}}
+        run: ./test/run_test.sh continue-when-build-fails
+
       - name: Build release tarball
         if: startsWith(github.ref, 'refs/tags/')
         run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Continue installing relevant tools even when some builds have failed (#133)
 - Fix OCamlformat is not installed to the right version if it was already
   installed. (#127)
 

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -13,7 +13,7 @@ type tool = {
 }
 
 module Communication = struct
-  let list_plural list singular plural ppf =
+  let list_plural singular plural ppf list =
     match list with
     | [ _ ] -> Format.fprintf ppf "%s" singular
     | _ -> Format.fprintf ppf "%s" plural
@@ -44,9 +44,10 @@ module Communication = struct
     | tools_not_installed ->
         Logs.app (fun m ->
             m
-              "  -> The following %t been installed: %a. Run with `-v` for \
+              "  -> The following %a been installed: %a. Run with `-v` for \
                more information."
-              (list_plural tools_not_installed "tool hasn't" "tools haven't")
+              (list_plural "tool hasn't" "tools haven't")
+              tools_not_installed
               Fmt.(list ~sep:(any ", ") string)
               tools_not_installed)
 
@@ -54,8 +55,9 @@ module Communication = struct
     | [] -> Logs.app (fun m -> m "  -> Nothing to install.")
     | tools_to_install ->
         Logs.app (fun m ->
-            m "  -> The following %t now installed: %a."
-              (list_plural tools_to_install "tool is" "tools are")
+            m "  -> The following %a now installed: %a."
+              (list_plural "tool is" "tools are")
+              tools_to_install
               Fmt.(list ~sep:(any ", ") string)
               (List.map fst tools_to_install))
 

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -13,7 +13,7 @@ type tool = {
 }
 
 module Communication = struct
-  let list_plural list ppf (singular, plural) =
+  let list_plural list singular plural ppf =
     match list with
     | [ _ ] -> Format.fprintf ppf "%s" singular
     | _ -> Format.fprintf ppf "%s" plural
@@ -44,10 +44,9 @@ module Communication = struct
     | tools_not_installed ->
         Logs.app (fun m ->
             m
-              "  -> The following %a been installed: %a. Run with `-v` for \
+              "  -> The following %t been installed: %a. Run with `-v` for \
                more information."
-              (list_plural tools_not_installed)
-              ("tool hasn't", "tools haven't")
+              (list_plural tools_not_installed "tool hasn't" "tools haven't")
               Fmt.(list ~sep:(any ", ") string)
               tools_not_installed)
 
@@ -55,9 +54,8 @@ module Communication = struct
     | [] -> Logs.app (fun m -> m "  -> Nothing to install.")
     | tools_to_install ->
         Logs.app (fun m ->
-            m "  -> The following %a now installed: %a."
-              (list_plural tools_to_install)
-              ("tool is", "tools are")
+            m "  -> The following %t now installed: %a."
+              (list_plural tools_to_install "tool is" "tools are")
               Fmt.(list ~sep:(any ", ") string)
               (List.map fst tools_to_install))
 

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -277,7 +277,9 @@ let install opam_opts tools =
       in
       Logs.app (fun m ->
           m "  -> The following %s now installed: %a."
-            (if tools_to_install = [] then "tool is" else "tools are")
+            (match tools_to_install with
+            | [ _ ] -> "tool is"
+            | _ -> "tools are")
             Fmt.(list ~sep:(any ", ") string)
             (List.map fst tools_to_install));
       Ok tools_failed)
@@ -286,7 +288,7 @@ let install opam_opts tools =
     Logs.app (fun m ->
         let l = tools_not_installed @ List.map (fun x -> fst x) tools_failed in
         m "  -> The following %s been installed: %a"
-          (if l = [] then "tool hasn't" else "tools haven't")
+          (match l with [ _ ] -> "tool hasn't" | _ -> "tools haven't")
           Fmt.(list ~sep:(any ", ") string)
           l)
   else Logs.app (fun m -> m "* Success.");

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -276,8 +276,8 @@ let install opam_opts tools =
         Communication.tell_version_result tool action ocaml_version;
         match action with
         | `Skip -> Ok acc
-        | `Install (version, Some build, _) ->
-            let to_build = ((tool.name, version), build) :: to_build in
+        | `Install (_, Some build, install) ->
+            let to_build = ((tool.name, install), build) :: to_build in
             Ok (to_build, in_cache, non_installable)
         | `Install (_, None, install) ->
             let in_cache = (tool.name, install) :: in_cache in

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -16,8 +16,7 @@ module Communication = struct
   let enter_version_stage () =
     Logs.app (fun m -> m "* Inferring tools version...")
 
-  let enter_building_stage tools_to_build =
-    if tools_to_build <> [] then Logs.app (fun m -> m "* Building the tools...")
+  let enter_building_stage () = Logs.app (fun m -> m "* Building the tools...")
 
   let enter_creating_sandbox () =
     Logs.app (fun m -> m "  -> Creating a sandbox...")
@@ -286,7 +285,8 @@ let install opam_opts tools =
         | `Error err -> Error err)
       ([], [], []) tools
   in
-  (Communication.enter_building_stage tools_to_build;
+  (if tools_to_build <> [] then (
+   Communication.enter_building_stage ();
    Communication.enter_creating_sandbox ();
    Sandbox_switch.with_sandbox_switch opam_opts ~ocaml_version (fun sandbox ->
        let n = List.length tools_to_build in
@@ -302,6 +302,7 @@ let install opam_opts tools =
                   (tools_built, (tool_name, e) :: tools_failed))
             ([], [])
             (List.mapi (fun i s -> (i, s)) tools_to_build))))
+  else Ok ([], []))
   >>= fun (tools_built, tools_failed) ->
   (Communication.enter_install_stage ();
    let tools_to_install = tools_in_cache @ tools_built in

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -13,6 +13,11 @@ type tool = {
 }
 
 module Communication = struct
+  let list_plural list ppf (singular, plural) =
+    match list with
+    | [ _ ] -> Format.fprintf ppf "%s" singular
+    | _ -> Format.fprintf ppf "%s" plural
+
   let enter_version_stage () =
     Logs.app (fun m -> m "* Inferring tools version...")
 
@@ -36,28 +41,23 @@ module Communication = struct
             m
               "* For more information on the platform tools, run \
                `ocaml-platform --help`")
-    | [ tool ] ->
-        Logs.app (fun m ->
-            m
-              "  -> The following tools hasn't been installed: %s. Run with \
-               `-v` for more information."
-              tool)
     | tools_not_installed ->
         Logs.app (fun m ->
             m
-              "  -> The following tools haven't been installed: %a. Run with \
-               `-v` for more information."
+              "  -> The following %a been installed: %a. Run with `-v` for \
+               more information."
+              (list_plural tools_not_installed)
+              ("tool hasn't", "tools haven't")
               Fmt.(list ~sep:(any ", ") string)
               tools_not_installed)
 
   let conclusion_installing = function
     | [] -> Logs.app (fun m -> m "  -> Nothing to install.")
-    | [ (tool, _) ] ->
-        Logs.app (fun m ->
-            m "  -> The following tool is now installed: %s." tool)
     | tools_to_install ->
         Logs.app (fun m ->
-            m "  -> The following tools are now installed: %a."
+            m "  -> The following %a now installed: %a."
+              (list_plural tools_to_install)
+              ("tool is", "tools are")
               Fmt.(list ~sep:(any ", ") string)
               (List.map fst tools_to_install))
 

--- a/test/dockerfiles/Dockerfile.continue-when-build-fails
+++ b/test/dockerfiles/Dockerfile.continue-when-build-fails
@@ -1,0 +1,14 @@
+ARG TARGETPLATFORM=$TARGETPLATFORM
+
+FROM ocaml-platform-build-$TARGETPLATFORM:latest as base
+
+FROM ocaml-platform-install-in-small-project-$TARGETPLATFORM:latest
+
+COPY --from=base /usr/local/bin/ocaml-platform /usr/local/bin/ocaml-platform
+
+RUN true
+    # https://stackoverflow.com/questions/51115856/docker-failed-to-export-image-failed-to-create-image-failed-to-get-layer
+
+COPY test/tests/failing_ocamlformat.sh .
+
+RUN bash failing_ocamlformat.sh

--- a/test/tests/failing_ocamlformat.sh
+++ b/test/tests/failing_ocamlformat.sh
@@ -1,0 +1,23 @@
+#/usr/bin/env bash
+set -euo pipefail
+
+# We modify the ocamlformat.0.24.1 package so that it won’t build (by setting wrong SHAs)
+sed -i 's/sha256=[a-zA-Z0-9]*/sha256=3b6a07254c78e5dfdd564178a4a99336bd5b6e79b6531efd7e537b73d4613fd2/g' ~/opam-repository/packages/ocamlformat/ocamlformat.0.24.1/opam
+sed -i 's/sha512=[a-zA-Z0-9]*/sha512=c38a5bc6ab23186fc2ab0ba08719e84b038c529c4d7d1f575227d8a02b0e23aa016e61276445be5e7ee725c4f471b409c4ec724bdd0ba7b1f94ae41a9c1396e5/g' ~/opam-repository/packages/ocamlformat/ocamlformat.0.24.1/opam 
+opam update
+
+# We removed installed versions
+opam remove ocamlformat+bin+platform odoc+bin+platform
+
+# And force next installation to be 0.24.1
+sed -i 's/0.19.0/0.24.1/g' .ocamlformat
+
+# Run the installed
+ocaml-platform -vv || echo "Fails because ocamlformat builds failed"
+
+# Check that ocaml-platform has updated the state as intended:
+# - ocamlformat binary package build has failed
+# - odoc has been reinstalled
+
+! opam show ocamlformat+bin+platform
+opam show odoc+bin+platform

--- a/test/tests/failing_ocamlformat.sh
+++ b/test/tests/failing_ocamlformat.sh
@@ -13,7 +13,7 @@ opam remove ocamlformat+bin+platform odoc+bin+platform
 sed -i 's/0.19.0/0.24.1/g' .ocamlformat
 
 # Run the installed
-ocaml-platform -vv || echo "Fails because ocamlformat builds failed"
+! ocaml-platform -vv
 
 # Check that ocaml-platform has updated the state as intended:
 # - ocamlformat binary package build has failed


### PR DESCRIPTION
Fixes #132 

Currently, it still ends with an error, but the error message is a bit misleading without the context... Here is an output when the build of ocamlformat fails (the settings of the test):

```
opam@27c407da8c89:~/helloworld$ ocaml-platform
* Inferring tools version...                                                                                        
  -> dune is already installed
  -> dune-release.1.6.2 will be installed from cache
  -> merlin.4.6-413 will be installed from cache
  -> ocaml-lsp-server.1.10.5 will be installed from cache
  -> odoc.2.1.1 will be installed from cache
  -> ocamlformat.0.24.1 will be built from source
* Building the tools...
  -> Creating a sandbox...
  -> [1/1] Building ocamlformat...
ocaml-platform: [WARNING] There was an error during build of ocamlformat. Run with `-v` for more information.
* Installing tools...
  -> The following tools are now installed: odoc, ocaml-lsp-server, merlin, dune-release.
  -> The following tools haven't been installed: ocamlformat
* For more information on the platform tools, run `ocaml-platform --help`
ocaml-platform: [ERROR] Command 'opam install ocamlformat.0.24.1 --yes -q --color=never --switch
           /tmp/ocaml-platform-sandbox-9204f9 --root /home/opam/.opam' failed: exited with 40
opam@27c407da8c89:~/helloworld$
```