### PR TITLE
Don't persist sandbox compiler packages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Fix cached compiler package out of date. (#136)
 - Continue installing relevant tools even when some builds have failed (#133)
 - Fix OCamlformat is not installed to the right version if it was already
   installed. (#127)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-- Fix cached compiler package out of date. (#136)
+- Fix cached compiler package potentially being out of date. (#136)
 - Continue installing relevant tools even when some builds have failed (#133)
 - Fix OCamlformat is not installed to the right version if it was already
   installed. (#127)

--- a/src/lib/import.ml
+++ b/src/lib/import.ml
@@ -1,6 +1,7 @@
 module Result = struct
   include Stdlib.Result
 
+  type msg = [ `Msg of string ]
   type ('a, 'e) or_msg = ('a, ([> `Msg of string | `Multi of 'e list ] as 'e)) t
 
   module Syntax = struct
@@ -44,3 +45,7 @@ module Result = struct
 
   let errorf fmt = Format.kasprintf (fun msg -> Error (`Msg msg)) fmt
 end
+
+let with_tmp_dir suffix f =
+  let f p () = f p in
+  Bos.OS.Dir.with_tmp ("ocaml-platform-" ^^ suffix ^^ "-%s") f () |> Result.join

--- a/src/lib/import.ml
+++ b/src/lib/import.ml
@@ -1,7 +1,6 @@
 module Result = struct
   include Stdlib.Result
 
-  type msg = [ `Msg of string ]
   type ('a, 'e) or_msg = ('a, ([> `Msg of string | `Multi of 'e list ] as 'e)) t
 
   module Syntax = struct

--- a/src/lib/import.mli
+++ b/src/lib/import.mli
@@ -4,7 +4,6 @@
 module Result : sig
   include module type of Stdlib.Result
 
-  type msg = [ `Msg of string ]
   type ('a, 'e) or_msg = ('a, ([> `Msg of string | `Multi of 'e list ] as 'e)) t
 
   module Syntax : sig
@@ -30,7 +29,7 @@ end
 
 val with_tmp_dir :
   (string -> string, Format.formatter, unit, string -> string) format4 ->
-  (Fpath.t -> ('a, ([> Result.msg ] as 'e)) result) ->
+  (Fpath.t -> ('a, ([> `Msg of string ] as 'e)) result) ->
   ('a, 'e) result
 (** Create and delete a temporary directory. The first argument is a string
     literal for naming the new directory, which will be concatenated to a more

--- a/src/lib/import.mli
+++ b/src/lib/import.mli
@@ -4,6 +4,7 @@
 module Result : sig
   include module type of Stdlib.Result
 
+  type msg = [ `Msg of string ]
   type ('a, 'e) or_msg = ('a, ([> `Msg of string | `Multi of 'e list ] as 'e)) t
 
   module Syntax : sig
@@ -26,3 +27,11 @@ module Result : sig
   val errorf :
     ('a, Format.formatter, unit, (_, [> `Msg of string ]) t) format4 -> 'a
 end
+
+val with_tmp_dir :
+  (string -> string, Format.formatter, unit, string -> string) format4 ->
+  (Fpath.t -> ('a, ([> Result.msg ] as 'e)) result) ->
+  ('a, 'e) result
+(** Create and delete a temporary directory. The first argument is a string
+    literal for naming the new directory, which will be concatenated to a more
+    unique name internally. *)

--- a/src/lib/opam.ml
+++ b/src/lib/opam.ml
@@ -159,7 +159,7 @@ module Repository = struct
 
   let remove opam_opts name =
     Cmd.run opam_opts
-      Bos.Cmd.(v "repository" % "--this-switch" % "remove" % name)
+      Bos.Cmd.(v "repository" % "remove" % "--all-switches" % name)
 end
 
 module Show = struct

--- a/src/lib/opam.mli
+++ b/src/lib/opam.mli
@@ -58,8 +58,10 @@ end
 module Repository : sig
   val add :
     GlobalOpts.t -> path:Fpath.t -> string -> (unit, [> `Msg of string ]) result
+  (** Add a repository, act on the switch selected by the options. *)
 
   val remove : GlobalOpts.t -> string -> (unit, [> `Msg of string ]) result
+  (** Remove a repository, act on all switches. *)
 end
 
 module Show : sig

--- a/src/lib/sandbox_compiler_package.mli
+++ b/src/lib/sandbox_compiler_package.mli
@@ -1,5 +1,10 @@
 open Import
 
-val init : Opam.GlobalOpts.t -> string -> (Repo.t * string, 'e) Result.or_msg
-(** [init opam_opts ocaml_version] creates (if needed) a repo containing a
-    patched version of [ocaml-system] working well with the sandbox switch. *)
+val with_sandbox_compiler_repo :
+  Opam.GlobalOpts.t ->
+  string ->
+  (string -> ('a, ([> Result.msg ] as 'e)) result) ->
+  ('a, 'e) result
+(** [init opam_opts ocaml_version f] creates a temporary repo containing a
+    patched version of [ocaml-system] working well with the sandbox switch. The
+    name of the compiler package is given to [f]. *)

--- a/src/lib/sandbox_compiler_package.mli
+++ b/src/lib/sandbox_compiler_package.mli
@@ -1,10 +1,8 @@
-open Import
-
 val with_sandbox_compiler_repo :
   Opam.GlobalOpts.t ->
   string ->
-  (string -> ('a, ([> Result.msg ] as 'e)) result) ->
+  (string -> ('a, ([> `Msg of string ] as 'e)) result) ->
   ('a, 'e) result
-(** [init opam_opts ocaml_version f] creates a temporary repo containing a
-    patched version of [ocaml-system] working well with the sandbox switch. The
-    name of the compiler package is given to [f]. *)
+(** [with_sandbox_compiler_repo opam_opts ocaml_version f] creates a temporary
+    repo containing a patched version of [ocaml-system] working well with the
+    sandbox switch. The name of the compiler package is given to [f]. *)

--- a/src/lib/sandbox_switch.ml
+++ b/src/lib/sandbox_switch.ml
@@ -8,12 +8,6 @@ type t = {
       (** Opam options to use when running command targeting the switch. *)
   prefix : Fpath.t;
       (** Root directory of the switch, containing [bin/], [lib/], etc.. *)
-  sandbox_root : Fpath.t;
-      (** The directory in which the sandbox switch has been created. Created
-          during [init] and removed during [deinit]. *)
-  compiler_path : Fpath.t;
-      (** A folder containing symlinks to the compiler tools. Created during
-          [init] and removed during [deinit]. *)
 }
 
 let compiler_tools =
@@ -42,11 +36,11 @@ let compiler_suffixes = [ ""; ".opt"; ".byte" ]
 
 (** Make the [compiler_path] directory. [parent_prefix] is the prefix of the
     switch from which we reuse the compiler. *)
-let make_compiler_path parent_prefix =
-  let* compiler_path = OS.Dir.tmp "ocaml-platform-system-compiler-%s" in
+let with_compiler_path parent_prefix f =
+  with_tmp_dir "system-compiler" @@ fun compiler_path ->
   let ( / ) = Fpath.( / ) in
   let parent_prefix = parent_prefix / "bin" in
-  let+ () =
+  let* () =
     Result.List.fold_left
       (fun () fname ->
         Result.List.fold_left
@@ -59,7 +53,7 @@ let make_compiler_path parent_prefix =
           () compiler_suffixes)
       () compiler_tools
   in
-  compiler_path
+  f compiler_path
 
 (** The [switch] field will be passed with [--switch] and [env] is used to set
     the [PATH] variable. *)
@@ -75,43 +69,33 @@ let make_sandbox_opts opam_opts ~compiler_path ~sandbox_root =
   let switch = Some (Fpath.to_string sandbox_root) in
   { opam_opts with Opam.GlobalOpts.switch; env = Some env }
 
-let init opam_opts ~ocaml_version =
+let with_opam_switch ~ocaml_version opam_opts name f =
+  (* Remove the sandbox switch from Opam's state. It's not a big deal if this
+     fails or is never run due to a Ctrl+C, Opam will cleanup its state the next
+     time it does a read-write operation. *)
+  let* () = Opam.Switch.create ~ocaml_version opam_opts name in
+  let finally () = ignore (Opam.Switch.remove opam_opts name) in
+  Fun.protect ~finally f
+
+let with_sandbox_switch opam_opts ~ocaml_version f =
   (* Directory in which to create the switch. *)
-  let* sandbox_root = OS.Dir.tmp "ocaml-platform-sandbox-%s" in
-  let* compiler_path =
-    let* parent_prefix = Opam.Config.Var.get opam_opts "prefix" in
-    make_compiler_path (Fpath.v parent_prefix)
-  in
+  with_tmp_dir "sandbox" @@ fun sandbox_root ->
+  let* parent_prefix = Opam.Config.Var.get opam_opts "prefix" in
+  (* PATH containing the parent compiler. *)
+  with_compiler_path (Fpath.v parent_prefix) @@ fun compiler_path ->
+  Logs.info (fun l -> l "Creating sandbox switch for building the tools");
+  with_opam_switch ~ocaml_version:None opam_opts (Fpath.to_string sandbox_root)
+  @@ fun () ->
+  (* Options for running commands inside the new switch. *)
   let* sandbox_opts =
     make_sandbox_opts opam_opts ~compiler_path ~sandbox_root
   in
-  let* () =
-    Logs.info (fun l -> l "Creating sandbox switch for building the tools");
-    let* () =
-      Opam.Switch.create ~ocaml_version:None opam_opts
-        (Fpath.to_string sandbox_root)
-    in
-    let* repo, compiler_package =
-      Sandbox_compiler_package.init opam_opts ocaml_version
-    in
-    let* () =
-      Opam.Repository.add sandbox_opts ~path:(Repo.path repo) (Repo.name repo)
-    in
-    Opam.install sandbox_opts [ compiler_package ]
-  in
+  (* Patched compiler package description. *)
+  Sandbox_compiler_package.with_sandbox_compiler_repo sandbox_opts ocaml_version
+  @@ fun compiler_package ->
+  let* () = Opam.install sandbox_opts [ compiler_package ] in
   let* prefix = Opam.Config.Var.get sandbox_opts "prefix" >>| Fpath.v in
-  Ok { sandbox_opts; sandbox_root; prefix; compiler_path }
-
-let deinit opam_opts t =
-  (* Remove the sandbox switch from Opam's state. It's not a big deal if this
-     fails or is never run, Opam will cleanup its state the next time it does a
-     read-write operation. *)
-  ignore (Opam.Switch.remove opam_opts (Fpath.to_string t.sandbox_root));
-  (* Deleting temporary directories is not strictly necessary, it will also be
-     done at [at_exit]. *)
-  ignore (OS.Dir.delete ~recurse:true t.sandbox_root);
-  ignore (OS.Dir.delete ~recurse:true t.compiler_path);
-  ()
+  f { sandbox_opts; prefix }
 
 let pkg_to_string (pkg_name, pkg_ver) = pkg_name ^ "." ^ pkg_ver
 
@@ -124,9 +108,3 @@ let list_files _opam_opts t ~pkg =
   List.map Fpath.v files
 
 let switch_path_prefix t = t.prefix
-
-let with_sandbox_switch opam_opts ~ocaml_version f =
-  let* sandbox = init opam_opts ~ocaml_version in
-  Fun.protect
-    ~finally:(fun () -> deinit opam_opts sandbox)
-    (fun () -> f sandbox)


### PR DESCRIPTION
Might fix https://github.com/tarides/ocaml-platform-installer/issues/130

These packages are only needed while building in the sandbox switch and are not costly to re-create every time. This eliminate bugs due to outdated persisted data.

'Sandbox_compiler_package' is rewritten in the "with_resource" style to accomodate the new 'with_sandbox_compiler_repo' function. This remove the tedious 'deinit' code and the need to add more book keeping for the new temporary directory.