### PR TITLE
Cache migration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,6 +83,10 @@ jobs:
         if: ${{matrix.platform.target_arch == 'x86_64'}}
         run: ./test/run_test.sh reinstall_cached
 
+      - name: "Test: migrate_01"
+        if: ${{matrix.platform.target_arch == 'x86_64'}}
+        run: ./test/run_test.sh migrate_01
+
       - name: "Test: reinstall_ocamlformat"
         if: ${{matrix.platform.target_arch == 'x86_64'}}
         run: ./test/run_test.sh reinstall_ocamlformat

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Add a versionning and migration mechanism for the cache. (#137)
 - Fix messages when there's nothing to install (#142)
 - Consider all tools as pure binaries packages (#134)
 - Keep cache repository enabled, for normal and pinned compilers. (#140)

--- a/src/lib/cache.ml
+++ b/src/lib/cache.ml
@@ -6,12 +6,16 @@ open Result.Syntax
 module Migrate = struct
   let current_version = 1
 
-  let migrate v =
+  let migrate_data v =
     if v = 0 then ();
     Ok ()
 
   let version_file plugin_path =
     Fpath.( / ) plugin_path "ocaml-platform-version"
+
+  let parse_version = function
+    | [] | _ :: _ :: _ -> None
+    | [ v ] -> int_of_string_opt v
 
   let read_version plugin_path =
     let* pexists = OS.Dir.exists plugin_path in
@@ -22,37 +26,41 @@ module Migrate = struct
       if not vexists then Ok 0 (* Old enough to not have a version file *)
       else
         let* vcontent = OS.File.read_lines version_file in
-        match vcontent with
-        | [] | _ :: _ :: _ -> Error `Invalid_version
-        | [ v ] -> (
-            match int_of_string_opt v with
-            | None -> Error `Invalid_version
-            | Some v when v < 0 -> Error `Invalid_version
-            | Some v when v > current_version -> Error `Future_version
-            | Some v -> Ok v)
+        match parse_version vcontent with
+        | None -> Result.errorf "Couldn't read cache version"
+        | Some v when v > current_version -> Error `Future_version
+        | Some v -> Ok v
 
   let save_current_version plugin_path =
     OS.File.write_lines (version_file plugin_path)
       [ string_of_int current_version ]
 
-  let clear_plugin_data plugin_path = OS.Dir.delete ~recurse:true plugin_path
+  let wipe_plugin_data plugin_path = OS.Dir.delete ~recurse:true plugin_path
 
-  (** Store a version number inside the repo directory indicating to allow
-      migrating the layout and clear obsolete packages. Operate on the files
-      directory, should be done before doing anything with the repository. *)
-  let check plugin_path =
-    match read_version plugin_path with
-    | Ok version when version = current_version -> Ok ()
-    | Ok version ->
-        let* () = migrate version in
-        save_current_version plugin_path
-    | Error `Invalid_version -> clear_plugin_data plugin_path
+  (** Store a version number inside the repo directory to allow migrating the
+      layout and clear obsolete packages. Operate on the files directory for
+      flexibility, should be done before doing anything with the repository. *)
+  let migrate plugin_path =
+    let* version = read_version plugin_path in
+    if version = current_version then Ok ()
+    else
+      let* () = migrate_data version in
+      save_current_version plugin_path
+
+  (** Don't let an error disturb the workflow, wipe the cache. *)
+  let migrate plugin_path =
+    match migrate plugin_path with
+    | Ok () as ok -> ok
     | Error `Future_version ->
         Result.errorf
           "ocaml-platform was downgraded. Please either install a newer \
-           version or remove the directory %a"
+           version or remove the directory '%a'."
           Fpath.pp plugin_path
-    | Error #R.msg as e -> e
+    | Error (`Msg msg) ->
+        Logs.warn (fun f ->
+            f "Deleting the cache due to a migration error (%s)" msg);
+        let* () = wipe_plugin_data plugin_path in
+        Ok ()
 end
 
 type t = {
@@ -66,7 +74,7 @@ let load opam_opts ~pinned =
     Fpath.(opam_opts.Opam.GlobalOpts.root / "plugins" / "ocaml-platform")
   in
   let global_binary_repo_path = Fpath.( / ) plugin_path "cache" in
-  let* () = Migrate.check plugin_path in
+  let* () = Migrate.migrate plugin_path in
   let* global_repo =
     Binary_repo.init ~name:"platform-cache" global_binary_repo_path
   in

--- a/src/lib/cache.ml
+++ b/src/lib/cache.ml
@@ -99,10 +99,16 @@ module Migrate_0_to_1 : Migrater = struct
   let migrate_archive archive =
     modify_name (migrate_suffix ~suffix:".tar.gz") archive
 
+  (** Compiler packages are now generated on the fly. Remove unused repo. *)
+  let remove_sandbox_compiler_packages plugin_path =
+    let repo_path = plugin_path / "platform_sandbox_compiler_packages" in
+    OS.Dir.delete ~recurse:true repo_path
+
   (** Migrate all packages and archives. *)
   let migrate plugin_path =
     let packages_path = plugin_path / "cache" / "repo" / "packages" in
     let* () = iter_subdir migrate_package packages_path in
+    let* () = remove_sandbox_compiler_packages plugin_path in
     let archive_path = plugin_path / "cache" / "archives" in
     iter_subdir migrate_archive archive_path
 end

--- a/test/dockerfiles/Dockerfile.migrate_01
+++ b/test/dockerfiles/Dockerfile.migrate_01
@@ -1,0 +1,13 @@
+ARG TARGETPLATFORM=$TARGETPLATFORM
+
+FROM ocaml-platform-build-$TARGETPLATFORM:latest as base
+
+FROM panglesd/ocaml-platform-installer:ocaml-platform-install-linux_amd64-v0.6.0
+
+COPY --from=base /usr/local/bin/ocaml-platform /usr/local/bin/ocaml-platform
+
+RUN true
+
+COPY test/tests/reinstall_cached.sh .
+
+RUN bash reinstall_cached.sh


### PR DESCRIPTION
Rebased on top of both https://github.com/tarides/ocaml-platform-installer/pull/135 and https://github.com/tarides/ocaml-platform-installer/pull/136 (must be rebased and merged last)

Fix https://github.com/tarides/ocaml-platform-installer/issues/131

This adds a mechanism to migrate the cache after the tool is upgraded. The cache has an incrementing version number written to it, which is checked before doing anything with it.

TODO:

- [x] Test. I'm considering adding cram tests, which need some work to run quickly.
- [x] Migration for https://github.com/tarides/ocaml-platform-installer/pull/134
- [x] Rebase