### PR TITLE
Keep the cache repository enabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Keep cache repository enabled, for normal and pinned compilers. (#140)
 - Fix cached compiler package potentially being out of date. (#136)
 - Continue installing relevant tools even when some builds have failed (#133)
 - Fix OCamlformat is not installed to the right version if it was already

--- a/src/lib/cache.ml
+++ b/src/lib/cache.ml
@@ -38,14 +38,13 @@ let has_binary_pkg t ~ocaml_version_dependent bname =
 
 let push_repo t = Option.value t.push_repo ~default:t.global_repo
 
-let with_repos_enabled opam_opts t f =
+let enable_repos opam_opts t =
   (* Add the global repository first. The last repo added will be looked up
      first. *)
   let repos = t.global_repo :: Option.to_list t.push_repo in
-  List.fold_left
-    (fun k repo () ->
+  Result.List.fold_left
+    (fun () repo ->
       let repo = Binary_repo.repo repo in
-      Installed_repo.with_repo_enabled opam_opts repo @@ fun () ->
-      let* () = Installed_repo.update opam_opts repo in
-      k ())
-    f repos ()
+      let* () = Installed_repo.enable_repo opam_opts repo in
+      Installed_repo.update opam_opts repo)
+    () repos

--- a/src/lib/cache.mli
+++ b/src/lib/cache.mli
@@ -1,4 +1,3 @@
-open Rresult
 open Import
 
 type t
@@ -7,16 +6,13 @@ type t
     packages that can't be stored in the global cache (eg. because building for
     a pinned compiler). *)
 
-val load :
-  Opam.GlobalOpts.t ->
-  pinned:bool ->
-  (t -> ('a, ([> R.msg ] as 'e)) result) ->
-  ('a, 'e) result
+val load : Opam.GlobalOpts.t -> pinned:bool -> (t, 'e) Result.or_msg
 (** Manage initialisation of the cache repository.
 
-    When building for a pinned compiler (indicated by [~pinned:true]), an
-    ephemeral repository is used instead of the global cache for storing the new
-    packages. *)
+    When building for a pinned compiler (indicated by [~pinned:true]), a local
+    repository is used instead of the global cache for storing the new packages.
+    The repository is stored in [<switch-prefix>/var/cache/ocaml-platform], and
+    its name is computed from [<switch-prefix>]. *)
 
 val has_binary_pkg :
   t -> ocaml_version_dependent:bool -> Binary_package.full_name -> bool
@@ -30,9 +26,6 @@ val has_binary_pkg :
 val push_repo : t -> Binary_repo.t
 (** The repository in which to add newly built packages. *)
 
-val enable_repos :
-  Opam.GlobalOpts.t ->
-  t ->
-  (unit, 'e) Result.or_msg
+val enable_repos : Opam.GlobalOpts.t -> t -> (unit, 'e) Result.or_msg
 (** [with_repos_enabled cache f] calls [f] with the global and the push repo
     enabled. *)

--- a/src/lib/cache.mli
+++ b/src/lib/cache.mli
@@ -1,4 +1,5 @@
 open Rresult
+open Import
 
 type t
 (** Represent the cache repositories for binary packages. The global cache is
@@ -29,10 +30,9 @@ val has_binary_pkg :
 val push_repo : t -> Binary_repo.t
 (** The repository in which to add newly built packages. *)
 
-val with_repos_enabled :
+val enable_repos :
   Opam.GlobalOpts.t ->
   t ->
-  (unit -> ('a, ([> R.msg ] as 'e)) result) ->
-  ('a, 'e) result
+  (unit, 'e) Result.or_msg
 (** [with_repos_enabled cache f] calls [f] with the global and the push repo
     enabled. *)

--- a/src/lib/installed_repo.ml
+++ b/src/lib/installed_repo.ml
@@ -7,3 +7,7 @@ let with_repo_enabled opam_opts t f =
   let unselect_repo () = ignore @@ Opam.Repository.remove opam_opts repo_name in
   Opam.Repository.add opam_opts ~path:repo_path repo_name >>= fun () ->
   Fun.protect ~finally:unselect_repo f
+
+let enable_repo opam_opts t =
+  let repo_name = Repo.name t and repo_path = Repo.path t in
+  Opam.Repository.add opam_opts ~path:repo_path repo_name

--- a/src/lib/installed_repo.mli
+++ b/src/lib/installed_repo.mli
@@ -8,3 +8,7 @@ val update : Opam.GlobalOpts.t -> Repo.t -> (unit, 'e) OS.result
 val with_repo_enabled :
   Opam.GlobalOpts.t -> Repo.t -> (unit -> (('a, 'e) OS.result as 'r)) -> 'r
 (** Temporarily enable a repository in the selected switch. *)
+
+val enable_repo :
+  Opam.GlobalOpts.t -> Repo.t -> (unit, [> `Msg of string ]) result
+(** Enable a repository in the selected switch. *)

--- a/src/lib/opam.ml
+++ b/src/lib/opam.ml
@@ -148,6 +148,8 @@ module Switch = struct
 
   let remove opam_opts name =
     Cmd.run_s opam_opts Bos.Cmd.(v "switch" % "remove" % name)
+
+  let show opam_opts = Cmd.run_s opam_opts Bos.Cmd.(v "switch" % "show")
 end
 
 module Repository = struct

--- a/src/lib/opam.mli
+++ b/src/lib/opam.mli
@@ -53,6 +53,7 @@ module Switch : sig
       installed. *)
 
   val remove : GlobalOpts.t -> string -> (string, [> `Msg of string ]) result
+  val show : GlobalOpts.t -> (string, [> `Msg of string ]) result
 end
 
 module Repository : sig

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -271,7 +271,7 @@ let install opam_opts tools =
   (Communication.enter_install_stage ();
    let tools_to_install = tools_in_cache @ tools_built in
    let* () =
-     Cache.with_repos_enabled opam_opts cache @@ fun () ->
+     let* () = Cache.enable_repos opam_opts cache in
      Opam.install
        { opam_opts with log_height = Some 10 }
        (List.map snd tools_to_install)

--- a/src/lib/tools.ml
+++ b/src/lib/tools.ml
@@ -221,7 +221,7 @@ let should_install_pkg opam_opts ~version_list ~ocaml_version ~cache tool =
 let install opam_opts tools =
   let* compiler_pkg, pinned = get_compiler_pkg opam_opts in
   let ocaml_version = Package.ver compiler_pkg in
-  Cache.load opam_opts ~pinned @@ fun cache ->
+  let* cache = Cache.load opam_opts ~pinned in
   (* [tools_to_build] is the list of tools that need to be built and placed in
      the cache. [tools_to_install] is the names of the packages to install into
      the user's switch, each string is a suitable argument to [opam install]. *)

--- a/test/tests/pin-ocaml-compiler.sh
+++ b/test/tests/pin-ocaml-compiler.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 cd $HOME
-git clone https://github.com/ocaml/ocaml
+git clone --branch 4.14 --single-branch https://github.com/ocaml/ocaml
 cd ocaml
 opam switch create --empty pinned
 opam install .


### PR DESCRIPTION
Implements #139 by putting the cache repository in `<switch-prefix>/var/cache/ocaml-platform`.