### PR TITLE
Avoid installing to /usr/local if it doesn't exist

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- Installer: Avoid installing into /usr/local if it doesn't exist. (#144)
+  Install into /usr as a fallback.
 - Add a versionning and migration mechanism for the cache. (#137)
 - Fix messages when there's nothing to install (#142)
 - Consider all tools as pure binaries packages (#134)

--- a/src/distrib/make_installer.sh
+++ b/src/distrib/make_installer.sh
@@ -50,7 +50,10 @@ set -euo pipefail
 #   https://archive.ph/xvQVA
 _() {
 
-PREFIX=\${PREFIX:-/usr/local}
+DEFAULT_PREFIX=/usr
+if [[ -d /usr/local ]]; then DEFAULT_PREFIX=/usr/local; fi
+
+PREFIX=\${PREFIX:-\$DEFAULT_PREFIX}
 
 targetarch=\$(uname -m || echo unknown)
 # Taken from Opam's installer


### PR DESCRIPTION
Fix https://github.com/tarides/ocaml-platform-installer/issues/141

Install the binary into `/usr/local/bin` only if it exists, otherwise install into `/usr/bin`.
The current 'install' command would install the platform binary as `/usr/local/bin` literally, which is highly unwanted.