### PR TITLE
Uniquely named and short-lived compiler sandbox repo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+- Fix sandbox creation failing as soon as a sandbox repo is left activated.
+  (#150)
+
 ## 0.7.0 (2022-12-12)
 
 - Installer: Avoid installing into /usr/local if it doesn't exist. (#144)

--- a/src/lib/sandbox_compiler_package.ml
+++ b/src/lib/sandbox_compiler_package.ml
@@ -82,6 +82,9 @@ let init_pkg_ocaml_system repo ~ocaml_version =
 let with_sandbox_compiler_repo opam_opts ocaml_version f =
   let ocaml_version = remove_alpha_plus_suffix ocaml_version in
   with_tmp_dir "compiler-package" @@ fun repo_path ->
+  (* Each repository used for a sandbox’s compiler must be uniquely named:
+     Otherwise, parallel execution would fail due to [opam] complaining that a
+     different repository with a similar name exists *)
   let hash = Hashtbl.hash repo_path in
   let name = Printf.sprintf "platform_sandbox_compiler_packages-%d" hash in
   let* repo = Repo.init ~name repo_path in

--- a/src/lib/sandbox_compiler_package.ml
+++ b/src/lib/sandbox_compiler_package.ml
@@ -81,8 +81,9 @@ let init_pkg_ocaml_system repo ~ocaml_version =
 
 let with_sandbox_compiler_repo opam_opts ocaml_version f =
   let ocaml_version = remove_alpha_plus_suffix ocaml_version in
-  let name = "platform_sandbox_compiler_packages" in
   with_tmp_dir "compiler-package" @@ fun repo_path ->
+  let hash = Hashtbl.hash repo_path in
+  let name = Printf.sprintf "platform_sandbox_compiler_packages-%d" hash in
   let* repo = Repo.init ~name repo_path in
   let* () = init_pkg_ocaml_system repo ~ocaml_version in
   let compiler_package = "ocaml-system." ^ ocaml_version in

--- a/src/lib/sandbox_switch.ml
+++ b/src/lib/sandbox_switch.ml
@@ -90,7 +90,9 @@ let with_sandbox_switch opam_opts ~ocaml_version f =
   let* sandbox_opts =
     make_sandbox_opts opam_opts ~compiler_path ~sandbox_root
   in
-  (* Patched compiler package description. *)
+  (* A patched compiler package description is needed. We install it from a
+     temporary repository which is removed as soon as the compiler is
+     installed. *)
   let* () =
     Sandbox_compiler_package.with_sandbox_compiler_repo sandbox_opts
       ocaml_version

--- a/src/lib/sandbox_switch.ml
+++ b/src/lib/sandbox_switch.ml
@@ -91,9 +91,11 @@ let with_sandbox_switch opam_opts ~ocaml_version f =
     make_sandbox_opts opam_opts ~compiler_path ~sandbox_root
   in
   (* Patched compiler package description. *)
-  Sandbox_compiler_package.with_sandbox_compiler_repo sandbox_opts ocaml_version
-  @@ fun compiler_package ->
-  let* () = Opam.install sandbox_opts [ compiler_package ] in
+  let* () =
+    Sandbox_compiler_package.with_sandbox_compiler_repo sandbox_opts
+      ocaml_version
+    @@ fun compiler_package -> Opam.install sandbox_opts [ compiler_package ]
+  in
   let* prefix = Opam.Config.Var.get sandbox_opts "prefix" >>| Fpath.v in
   f { sandbox_opts; prefix }
 


### PR DESCRIPTION
This PR makes sandbox repos as short-lived as possible (there is no need to keep them as soon as the compiler has been installed) and give them unique name depending on the path (adding a repo to opam, with an already existing name but a different path, makes it fail).

Should hopefully make #149 never happen again.