### PR TITLE
Fix CI

### DIFF
--- a/test/tests/pin-ocaml-compiler.sh
+++ b/test/tests/pin-ocaml-compiler.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 cd $HOME
-git clone --branch 4.14 --single-branch https://github.com/ocaml/ocaml
+git clone --branch 4.12 --single-branch https://github.com/ocaml/ocaml
 cd ocaml
 opam switch create --empty pinned
 opam install .


### PR DESCRIPTION
At the date of this commit, a new version of OCaml 4.14 was released. It might be the cause of the CI failing (maybe because docker images were not updated?). Testing on a pinned compiler version 4.12 fixes this.